### PR TITLE
Add a Buildpack Registry extension

### DIFF
--- a/extensions/registry.md
+++ b/extensions/registry.md
@@ -8,7 +8,7 @@ The following additional elements extend the [`buildpack.toml` data format](../b
   [publish.Ignore]
   files = ["<files to ignore>"]
 
-  [[publish.Vendor]]
+  [[publish.vendor]]
   url = "<url to download>"
   dir = "<directory to download>"
   files = ["<files to keep>"]

--- a/extensions/registry.md
+++ b/extensions/registry.md
@@ -5,7 +5,7 @@ The following additional elements extend the [`buildpack.toml` data format](../b
 ```toml
 [buildpack]
 
-  [publish.Ignore]
+  [publish.ignore]
   files = ["<files to ignore>"]
 
   [[publish.vendor]]

--- a/extensions/registry.md
+++ b/extensions/registry.md
@@ -1,0 +1,21 @@
+# Buildpack Registry API
+
+The following additional elements extend the [`buildpack.toml` data format](../buildpack.md#buildpacktoml-toml) section in the Buildpack Interface Specification.
+
+```toml
+[buildpack]
+
+  [publish.Ignore]
+  files = ["<files to ignore>"]
+
+  [[publish.Vendor]]
+  url = "<url to download>"
+  dir = "<directory to download>"
+  files = ["<files to keep>"]
+```
+
+The list of files to ignore is optional, and will be used by the Buildpack Registry
+to prune files from the repository when packaging a buildpack.
+
+The vendor key is optional, and will be used by the Buildpack Registry to download
+additional files for inclusion in the buildpack package.


### PR DESCRIPTION
This is a proposal for an extension to the Buildpack Interface Specification. It defines new elements in the `buildpack.toml` data format.

In the future there may be other additions we can make (such as more formal restrictions or guidelines around `buildpack.id`), but this is the best starting point.