### PR TITLE
Add application runtime extensions

### DIFF
--- a/extensions/app-runtime.md
+++ b/extensions/app-runtime.md
@@ -1,0 +1,51 @@
+# Application Runtime Extensions
+
+This document specifies a contract between a platform and processes running in an application OCI image.  
+
+## Runtime Environment Variables
+
+The following environment variables extend the [Environment - Provided by the Platform](../buildpack.md#provided-by-the-platform) section in the Buildpack Interface Specification.
+The are exclusively available during the launch phase.
+
+| Env Variable         | Example Value                    | Description                       | Mandatory
+|----------------------|----------------------------------|----------------------------------------------
+| `PORT`               | `8080`                           | port for primary web process type | [x]
+| `CNB_APP_ROUTES`     | `{"web":{"http":{"port":8080}}}` | routes for each process type      | [x]
+| `CNB_APP_INDEX`      | `0`                              | app instance index (logical)      | [x] 
+| `CNB_APP_NAME`       | `example-app`                    | app name                          |
+
+### Format: `CNB_APP_ROUTES`
+
+The `CNB_APP_ROUTES` enviroment variable MUST be JSON-formatted and follow this schema:
+
+```
+{
+    "<process type>": {
+        "<route name>": {
+            "port": <internal port>,
+            "uri": "<external uri>"
+        }
+    }
+}
+```
+
+Example:
+```
+{
+    "web": {
+        "http": {
+            "port": 8080,
+            "uri": "app.example.com"
+        },
+        "debug": {
+            "port": 12034,
+            "uri: "203.0.113.254:4444"
+        }
+    },
+    "worker": {
+        "debug": {
+            "port": 12035
+        }
+    }
+}
+```

--- a/extensions/app-runtime.md
+++ b/extensions/app-runtime.md
@@ -1,51 +1,60 @@
-# Application Runtime Extensions
+# Application Runtime Extension
 
-This document specifies a contract between a platform and processes running in an application OCI image.  
+This document specifies a contract between a platform and an application process running in an OCI image.
+
+This extension only applies to application process types.
 
 ## Runtime Environment Variables
 
 The following environment variables extend the [Environment - Provided by the Platform](../buildpack.md#provided-by-the-platform) section in the Buildpack Interface Specification.
 The are exclusively available during the launch phase.
 
-| Env Variable         | Example Value                    | Description                       | Mandatory
-|----------------------|----------------------------------|----------------------------------------------
-| `PORT`               | `8080`                           | port for primary web process type | [x]
-| `CNB_APP_ROUTES`     | `{"web":{"http":{"port":8080}}}` | routes for each process type      | [x]
-| `CNB_APP_INDEX`      | `0`                              | app instance index (logical)      | [x] 
-| `CNB_APP_NAME`       | `example-app`                    | app name                          |
+| Env Variable         | Example Value            | Description                   | Mandatory
+|----------------------|--------------------------|------------------------------------------
+| `PORT`               | `8080`                   | port for primary process type |
+| `CNB_APP_ROUTES`     | `{"http":{"port":8080}}` | routes for each process type  | [x]
+| `CNB_APP_INDEX`      | `0`                      | app instance index (logical)  | [x]
+| `CNB_APP_NAME`       | `example-app`            | app name                      | [x]
+
+### Format: `PORT`
+
+`PORT` MUST be an unsigned 16-bit integer.
 
 ### Format: `CNB_APP_ROUTES`
 
-The `CNB_APP_ROUTES` enviroment variable MUST be JSON-formatted and follow this schema:
+The `CNB_APP_ROUTES` environment variable MUST be JSON-formatted and follow this schema:
 
 ```
 {
-    "<process type>": {
-        "<route name>": {
-            "port": <internal port>,
-            "uri": "<external uri>"
-        }
+    "<route name>": {
+        "port": <internal port>,
+        "uri": "<external uri>"
     }
 }
 ```
+
+Where `port` MUST be an unsigned 16-bit integer if present.
+
 
 Example:
 ```
 {
-    "web": {
-        "http": {
-            "port": 8080,
-            "uri": "app.example.com"
-        },
-        "debug": {
-            "port": 12034,
-            "uri: "203.0.113.254:4444"
-        }
+    "http": {
+        "port": 8080,
+        "uri": "https://app.example.com/"
     },
-    "worker": {
-        "debug": {
-            "port": 12035
-        }
+    "debug": {
+        "port": 12034,
     }
 }
 ```
+
+### Format: `CNB_APP_INDEX`
+
+`CNB_APP_INDEX` MUST be a logical identifier that uniquely differentiates a single instance of an application from other instances.
+
+Examples: `1`, `01`, `web.1`
+
+### Format: `CNB_APP_NAME`
+
+`CNB_APP_NAME` MUST be a string that identifies the app. It SHOULD be unique among apps that it communicates with.

--- a/extensions/osbapi.md
+++ b/extensions/osbapi.md
@@ -1,8 +1,8 @@
 # Open Service Broker API
 
-The following additional environment variables extend the [Environment - Provided by the Platform](../buildpack.md#provided-by-the-platform) section in the Buildpack Interface Specification.
+The following environment variables extend the [Environment - Provided by the Platform](../buildpack.md#provided-by-the-platform) section in the Buildpack Interface Specification.
 
-| Env Variable    | Description                            | Detect | Build | Launch
+| Env Variable   | Description                            | Detect | Build | Launch
 |----------------|----------------------------------------|--------|-------|--------
 | `CNB_SERVICES` | OSBAPI service bindings                |        |       | [x]
 | `CNB_SERVICES` | OSBAPI service bindings (restricted)   | [x]    | [x]   |


### PR DESCRIPTION
Addresses #40 and #41. Also defines `PORT` environment variable, and an extended version called `CNB_APP_ROUTES`.