### PR TITLE
Remove Tags

### DIFF
--- a/extensions/bindings.md
+++ b/extensions/bindings.md
@@ -5,7 +5,7 @@ Bindings are exposed inside of a container during all three phases of the lifecy
 During the detect and build phases, the lifecycle MUST provide any bindings as files in `<platform>/bindings/<binding-name>` with directory names matching the name of the binding.  Binding names MUST match `[a-z0-9\-\.]{1,253}`.
 
 ### Metadata
-Within each binding directory the lifecycle MUST provide a `metadata` directory containing `kind`, `provider`, and `tags` files.  The value of the `kind` file MUST contain an abstract classification of the binding.  The value of the `provider` file MUST identify the provider of this binding.  The value of the `tags` file MUST contain a newline delimited collection of tags attached to the binding.
+Within each binding directory the lifecycle MUST provide a `metadata` directory containing `kind` and `provider` files.  The value of the `kind` file MUST contain an abstract classification of the binding.  The value of the `provider` file MUST identify the provider of this binding.
 
 In addition to the required files, the `metadata` directory MAY contain additional metadata about the binding with file names and contents matching the metadata names and contents.
 
@@ -34,14 +34,12 @@ If the `secret` directory exists, the contents of the files MAY change between d
     │   └── metadata
     │       ├── connection-count
     │       ├── kind
-    │       ├── provider
-    │       └── tags
+    │       └── provider
     └── secondary-db
         ├── metadata
         │   ├── connection-count
         │   ├── kind
-        │   ├── provider
-        │   └── tags
+        │   └── provider
         └── secret
             ├── endpoint
             ├── password
@@ -52,7 +50,7 @@ If the `secret` directory exists, the contents of the files MAY change between d
 During the launch phase, the lifecycle MUST provide any bindings as files in `$CNB_BINDINGS/<binding-name>` with directory names matching the name of the binding.  Binding names MUST match `[a-z0-9\-\.]{1,253}`.  The `CNB_BINDINGS` environment variable MUST be declared and can point to any valid filesystem location.
 
 ### Metadata
-Within each binding directory the lifecycle MUST provide a `metadata` directory containing `kind`, `provider`, and `tags` files.  The value of the `kind` file MUST contain an abstract classification of the binding.  The value of the `provider` file MUST identify the provider of this binding.  The value of the `tags` file MUST contain a newline delimited collection of tags attached to the binding.
+Within each binding directory the lifecycle MUST provide a `metadata` directory containing `kind` and `provider` files.  The value of the `kind` file MUST contain an abstract classification of the binding.  The value of the `provider` file MUST identify the provider of this binding.
 
 In addition to the required files, the `metadata` directory MAY contain additional metadata about the binding with file names and contents matching the metadata names and contents.
 
@@ -80,7 +78,6 @@ custom-bindings-location
 │   │   ├── connection-count
 │   │   ├── kind
 │   │   ├── provider
-│   │   └── tags
 │   └── secret
 │       ├── endpoint
 │       ├── password
@@ -90,7 +87,6 @@ custom-bindings-location
     │   ├── connection-count
     │   ├── kind
     │   ├── provider
-    │   └── tags
     └── secret
         ├── endpoint
         ├── password


### PR DESCRIPTION
Previously, the specification required a `tags` file that contained a set of arbitrary data.  This hasn't been used for anything particularly useful to date, and it has been pointed out that allowing arbitrary files in metadata can achieve the same ends.

Because of these observations, this change removes tags from the specification.
