### PR TITLE
detector/builder error codes

### DIFF
--- a/platform.md
+++ b/platform.md
@@ -82,8 +82,10 @@ The platform MUST ensure that:
 - The image config's `Label` field has the label `io.buildpacks.stack.id` set to the stack ID.
 - The image config's `Label` field has the label `io.buildpacks.stack.mixins` set to a JSON array containing mixin names for each mixin applied to the image.
 
+#### Detect
 To initiate the detection phase, the platform MUST invoke the `/cnb/lifecycle/detector` executable with the user and environment defined in the build image config.
 Invoking this executable with no flags is equivalent to the following invocation including all accepted flags and their default values.
+
 
 ```bash
 /cnb/lifecycle/detector -buildpacks /cnb/by-id -order /cnb/order.toml -group ./group.toml -plan ./plan.toml
@@ -96,8 +98,19 @@ Where:
 - `-group` MUST specify output to a `group.toml` file path as defined in the [Data Format](#data-format) section.
 - `-plan` MUST specify output to a Build Plan as defined in the [Buildpack Interface Specification](buildpack.md).
 
+The exit code returned by the `detector` MUST indicate the result of detection:
+
+| Exit Code | Result|
+|-----------|-------|
+| `0`       | Success
+| `100`     | All buildpacks groups have failed to detect w/o error
+| `101`     | All buildpack groups have failed to detect and at least one buildpack has errored
+| `1-99`, `102+`| Lifecycle error
+
+#### Build
 To initiate the build phase, the platform MUST invoke the `/cnb/lifecycle/builder` executable with the user and environment defined in the build image config.
 Invoking this executable with no flags is equivalent to the following invocation including all accepted flags and their default values.
+
 
 ```bash
 /cnb/lifecycle/builder -buildpacks /cnb/by-id -group ./group.toml -plan ./plan.toml
@@ -108,6 +121,14 @@ Where:
 - `-buildpacks` MUST specify input from a buildpacks directory as defined in the [Buildpacks Directory Layout](#buildpacks-directory-layout) section.
 - `-group` MUST specify input from a `group.toml` file path as defined in the [Data Format](#data-format) section.
 - `-plan` MUST specify input from a Build Plan as defined in the [Buildpack Interface Specification](buildpack.md).
+
+The exit code returned by the `builder` MUST indicate the build result:
+
+| Exit Code | Result|
+|-----------|-------|
+| `0`       | Success
+| `101`     | Buildpack error
+| `1-100`, `102+`| Lifecycle error
 
 ### Run Image
 


### PR DESCRIPTION
Platforms may wish to disambiguate detection failures from detection errors in order to provide users with meaningful output. Similarly, it is useful to platform authors to disambiguate lifecycle
errors from buildpack errors when debugging or interpreting failures. Specified error codes for
detection failures and buildpack errors provide this information.

Context:
I think this (buildpacks/lifecycle#306) proposed change to lifecycle error codes would be valuable for users. Previously, lifecycle exit codes were not specified. We can make this change in lifecycle without adding exit codes to the spec, but I think it would be good to codify certain exit codes in the platform API (like we do in the buildpack API).