### PR TITLE
Removes version key from bom in io.buildpacks.build.metadata.label

### DIFF
--- a/platform.md
+++ b/platform.md
@@ -848,7 +848,6 @@ Where:
   "bom": [
     {
       "name": "<bom-entry-name>",
-      "version": "<bom-entry-version>",
       "metadata": {
         // arbitrary buildpack provided metadata
       },


### PR DESCRIPTION
Resolves #97 