### PR TITLE
Buildpack API in group and metadata

### DIFF
--- a/platform.md
+++ b/platform.md
@@ -841,7 +841,7 @@ group = [
 
 Where:
 
-- `id` and `version` and `api` MUST be present for each buildpack object in a group.
+- `id`, `version`, and `api` MUST be present for each buildpack object in a group.
 
 #### `metadata.toml` (TOML)
 ```toml
@@ -864,7 +864,7 @@ paths = ["<app sub-path glob>"]
 ```
 
 Where:
-- `id`, `version` and `api` MUST be present for each buildpack.
+- `id`, `version`, and `api` MUST be present for each buildpack.
 - `processes` contains the complete set of processes contributed by all buildpacks
 - `processes` contains the complete set of slice defined by all buildpacks
 - `bom` contains the Bill of Materials

--- a/platform.md
+++ b/platform.md
@@ -835,19 +835,20 @@ Where:
 
 ```toml
 group = [
-  { id = "<buildpack ID>", version = "<buildpack version>" }
+  { id = "<buildpack ID>", version = "<buildpack version>", api = "<buildpack API version>" }
 ]
 ```
 
 Where:
 
-- Both `id` and `version` MUST be present for each buildpack object in a group.
+- `id` and `version` and `api` MUST be present for each buildpack object in a group.
 
 #### `metadata.toml` (TOML)
 ```toml
 [[buildpacks]]
 id = "<buildpack ID>"
-version = "<buildpack Version>"
+version = "<buildpack version>"
+api = "<buildpack API version>"
 optional = false
 
 [[processes]]
@@ -863,7 +864,7 @@ paths = ["<app sub-path glob>"]
 ```
 
 Where:
-- Both `id` and `version` MUST be present for each buildpack.
+- `id`, `version` and `api` MUST be present for each buildpack.
 - `processes` contains the complete set of processes contributed by all buildpacks
 - `processes` contains the complete set of slice defined by all buildpacks
 - `bom` contains the Bill of Materials


### PR DESCRIPTION
Now that we have buidpack API dependent launch logic, the launcher needs the api of each buildpack to exist in metadata.toml so it can do the right thing
* See #116 for an example (arg parsing for direct=false processes)

Other phases may have buidpack API dependent logic as well. Adding the `api` to group.toml will provide this the api of each buildpack everywhere it is needed.

Signed-off-by: Emily Casey <ecasey@vmware.com>