### PR TITLE
Windows buildpacks

### DIFF
--- a/buildpack.md
+++ b/buildpack.md
@@ -617,13 +617,13 @@ In either case,
 - The lifecycle MUST order all `<layer>` paths provided by a given buildpack alphabetically ascending.
 - The lifecycle MUST separate each path with the OS path list separator (e.g. `:` on Linux, `;` on Windows).
 
-| Env Variable      | Layer Path   | Contents         | Build | Launch | *Linux* | *Windows* | 
-|-------------------|--------------|------------------|-------|--------|---------|-----------|
-| `PATH`            | `/bin`       | binaries         | [x]   | [x]    | [x]     | [x]       |
-| `LD_LIBRARY_PATH` | `/lib`       | shared libraries | [x]   | [x]    | [x]     |           |
-| `LIBRARY_PATH`    | `/lib`       | static libraries | [x]   |        | [x]     |           |
-| `CPATH`           | `/include`   | header files     | [x]   |        | [x]     | [x]       |
-| `PKG_CONFIG_PATH` | `/pkgconfig` | pc files         | [x]   |        | [x]     | [x]       |
+| Env Variable                               | Layer Path   | Contents         | Build | Launch |
+|--------------------------------------------|--------------|------------------|-------|--------|
+| `PATH`                                     | `/bin`       | binaries         | [x]   | [x]    |
+| [†](README.md#linux-only)`LD_LIBRARY_PATH` | `/lib`       | shared libraries | [x]   | [x]    |
+| [†](README.md#linux-only)`LIBRARY_PATH`    | `/lib`       | static libraries | [x]   |        |
+| `CPATH`                                    | `/include`   | header files     | [x]   |        |
+| `PKG_CONFIG_PATH`                          | `/pkgconfig` | pc files         | [x]   |        |
 
 
 ### Provided by the Platform

--- a/buildpack.md
+++ b/buildpack.md
@@ -119,8 +119,8 @@ Executable: `/bin/detect <platform[AR]> <plan[E]>`, Working Dir: `<app[AR]>`
 | Output             | Description
 |--------------------|----------------------------------------------
 | [exit status]      | Pass (0), fail (100), or error (1-99, 101+)
-| `/dev/stdout`      | Logs (info)
-| `/dev/stderr`      | Logs (warnings, errors)
+| Standard output    | Logs (info)
+| Standard error     | Logs (warnings, errors)
 | `<plan>`           | Contributions to the the Build Plan (TOML)
 
 
@@ -138,8 +138,8 @@ Executable: `/bin/build <layers[EIC]> <platform[AR]> <plan[E]>`, Working Dir: `<
 | Output                                   | Description
 |------------------------------------------|--------------------------------------
 | [exit status]                            | Success (0) or failure (1+)
-| `/dev/stdout`                            | Logs (info)
-| `/dev/stderr`                            | Logs (warnings, errors)
+| Standard output                          | Logs (info)
+| Standard error                           | Logs (warnings, errors)
 | `<plan>`                                 | Refinements to the [Buildpack Plan](#buildpack-plan-toml) (TOML)
 | `<layers>/launch.toml`                   | App metadata (see [launch.toml](#launchtoml-toml))
 | `<layers>/store.toml`                    | Persistent metadata (see [store.toml](#storetoml-toml))
@@ -210,9 +210,10 @@ The lifecycle MUST consider layers that are marked `launch = false` and `build =
 
 ## App Interface
 
-| Output           | Description
-|------------------|----------------------------------------------
-| `<app>/.profile` | Script sourced by bash before launch
+| Output                 | Description
+|------------------------|----------------------------------------------
+| `<app>/.profile`       | [†](README.md#linux-only) Bash-formatted script sourced by shell before launch
+| `<app>/.profile.bat`   | [‡](README.md#windows-only) BAT-formatted script sourced by shell before launch
 
 ## Phase #1: Detection
 
@@ -226,8 +227,9 @@ These buildpacks must be compatible with the app.
 ### Process
 
 **GIVEN:**
-- An ordered list of buildpack groups resolved into buildpack implementations as described in [Order Resolution](#order-resolution) and
-- A directory containing application source code,
+- An ordered list of buildpack groups resolved into buildpack implementations as described in [Order Resolution](#order-resolution)
+- A directory containing application source code
+- A shell, if needed,
 
 For each buildpack in each group in order, the lifecycle MUST execute `/bin/detect`.
 
@@ -405,7 +407,7 @@ This is achieved by:
 - The Buildpack Plan,
 - Any `<layers>/<layer>.toml` files placed on the filesystem during the analysis phase,
 - Any locally cached `<layers>/<layer>` directories, and
-- Bash version 3 or greater, if needed,
+- A shell, if needed,
 
 For each buildpack in the group in order, the lifecycle MUST execute `/bin/build`.
 
@@ -546,7 +548,7 @@ The purpose of launch is to modify the running app environment using app-provide
 
 **GIVEN:**
 - An OCI image exported by the lifecycle,
-- Bash version 3 or greater, if needed,
+- A shell, if needed,
 
 First, the lifecycle MUST locate a start command and choose an execution strategy.
 
@@ -556,7 +558,7 @@ To choose an execution strategy,
 
 1. **IF** a buildpack-provided process type is chosen as the start command,
    1. **IF** the process type does not have `direct` set to `true`,
-      **THEN** the lifecycle MUST invoke the value of `command` as a command using Bash with values of `args` provided as arguments.
+      **THEN** the lifecycle MUST invoke the value of `command` as a command using the shell with values of `args` provided as arguments.
 
    2. **IF** the process type does have `direct` set to `true`,
       **THEN** the lifecycle MUST invoke the value of `command` using the `execve` syscall with values of `args` provided as arguments.
@@ -568,7 +570,7 @@ Given the start command and execution strategy,
 
 1. The lifecycle MUST set all buildpack-provided launch environment variables as described in the [Environment](#environment) section.
 
-2. If using an execution strategy involving Bash, the lifecycle MUST use a single Bash process to
+2. If using an execution strategy involving a shell, the lifecycle MUST use a single shell process to
    1. source each file in each `<layers>/<layer>/profile.d` directory,
       1. Firstly, in order of `/bin/build` execution used to construct the OCI image.
       2. Secondly, in alphabetically ascending order by layer directory name.
@@ -577,12 +579,15 @@ Given the start command and execution strategy,
       1. Firstly, in order of `/bin/build` execution used to construct the OCI image.
       2. Secondly, in alphabetically ascending order by layer directory name.
       3. Thirdly, in alphabetically ascending order by file name.
-   3. source `<app>/.profile` if it is present.
+   3. source [†](README.md#linux-only)`<app>/.profile` or [‡](README.md#windows-only)`<app>/.profile.bat` if it is present.
 
 3. The lifecycle MUST invoke the start command with the decided execution strategy.
 
-When executing a process using any execution strategy, the lifecycle SHOULD replace the lifecycle process in memory without forking it.
-When executing a process with Bash, the lifecycle SHOULD additionally replace the Bash process in memory without forking it.
+[†](README.md#linux-only)When executing a process using any execution strategy, the lifecycle SHOULD replace the lifecycle process in memory without forking it.
+
+[†](README.md#linux-only)When executing a process with Bash, the lifecycle SHOULD additionally replace the Bash process in memory without forking it.
+
+[‡](README.md#windows-only)When executing a process with Command Prompt, the lifecycle SHOULD start a new process with the same security context, terminal, working directory, STDIN/STDOUT/STDERR handles and environment variables as the Command Prompt process.
 
 ## Environment
 
@@ -610,15 +615,16 @@ In either case,
 
 - The lifecycle MUST order all `<layer>` paths to reflect the reversed order of the buildpack group.
 - The lifecycle MUST order all `<layer>` paths provided by a given buildpack alphabetically ascending.
-- The lifecycle MUST separate each path with the OS path list separator (e.g., `:` on Linux).
+- The lifecycle MUST separate each path with the OS path list separator (e.g. `:` on Linux, `;` on Windows).
 
-| Env Variable      | Layer Path   | Contents         | Build | Launch
-|-------------------|--------------|------------------|-------|--------
-| `PATH`            | `/bin`       | binaries         | [x]   | [x]
-| `LD_LIBRARY_PATH` | `/lib`       | shared libraries | [x]   | [x]
-| `LIBRARY_PATH`    | `/lib`       | static libraries | [x]   |
-| `CPATH`           | `/include`   | header files     | [x]   |
-| `PKG_CONFIG_PATH` | `/pkgconfig` | pc files         | [x]   |
+| Env Variable      | Layer Path   | Contents         | Build | Launch | *Linux* | *Windows* | 
+|-------------------|--------------|------------------|-------|--------|---------|-----------|
+| `PATH`            | `/bin`       | binaries         | [x]   | [x]    | [x]     | [x]       |
+| `LD_LIBRARY_PATH` | `/lib`       | shared libraries | [x]   | [x]    | [x]     |           |
+| `LIBRARY_PATH`    | `/lib`       | static libraries | [x]   |        | [x]     |           |
+| `CPATH`           | `/include`   | header files     | [x]   |        | [x]     | [x]       |
+| `PKG_CONFIG_PATH` | `/pkgconfig` | pc files         | [x]   |        | [x]     | [x]       |
+
 
 ### Provided by the Platform
 
@@ -748,7 +754,7 @@ For each process, the buildpack:
 
 - MUST specify a `type` that is not identical to other process types provided by the same buildpack.
 - MUST specify a `command` that is either:
-  - A command sequence that is valid when executed using the Bash 3+ shell, if `args` is not specified.
+  - A command sequence that is valid when executed using the shell, if `args` is not specified.
   - A path to an executable or the file name of an executable in `$PATH`, if `args` is a list with zero or more elements.
 - MAY specify an `args` list to be passed directly to the specified executable.
 - MAY specify a `direct` boolean that bypasses the shell.


### PR DESCRIPTION
Move windows buildpacks changes from `platform/0.4` to `buildpack/0.4` 

Resolves #119 