### PR TITLE
Update Distribution Spec for Windows vs Linux Buildpackages

### DIFF
--- a/distribution.md
+++ b/distribution.md
@@ -24,7 +24,11 @@ A buildpackage MUST exist as either an OCI image on an image registry, an OCI im
 
 A `.cnb` file MUST be an uncompressed tar archive containing an OCI image. Its file name SHOULD end in `.cnb`.
 
-Each FS layer blob in the buildpackage intended to be a buildpack MUST contain a single buildpack at the following file path:
+[†](README.md#linux-only)For Linux buildpackages, all FS layers MUST be buildpack layers.
+
+[‡](README.md#windows-only)For Windows buildpackages, all FS layers MUST be either buildpack or OS layers.
+
+Each buildpack layer blob MUST contain a single buildpack at the following file path:
 
 ```
 /cnb/buildpacks/<buildpack ID>/<buildpack version>/

--- a/distribution.md
+++ b/distribution.md
@@ -24,7 +24,7 @@ A buildpackage MUST exist as either an OCI image on an image registry, an OCI im
 
 A `.cnb` file MUST be an uncompressed tar archive containing an OCI image. Its file name SHOULD end in `.cnb`.
 
-Each FS layer blob in the buildpackage MUST contain a single buildpack at the following file path:
+Each FS layer blob in the buildpackage intended to be a buildpack MUST contain a single buildpack at the following file path:
 
 ```
 /cnb/buildpacks/<buildpack ID>/<buildpack version>/


### PR DESCRIPTION
Updates layer expectations for Windows buildpackages

Signed-off-by: Andrew Meyer <meyeran@vmware.com>

----

This change accommodates Windows buildpackages, which currently require a base image in order to be pulled into a local docker daemon. ~~This may change in the future, and the clarification to the spec will allow for this flexibility, since it will no longer include any potential base layers in the contract.~~

Also, regarding the Windows specific blob format (where tar paths must be prefixed with `Files/`), see the last paragraph of [this spec page](https://github.com/buildpacks/spec#interpreting-paths-for-windows), as it is a blanket statement that covers all of the spec. Therefore we did not add the prefix to this dist spec specifically.