### PR TITLE
Adds character restrictions for process types.

### DIFF
--- a/buildpack.md
+++ b/buildpack.md
@@ -811,7 +811,7 @@ If multiple buildpacks define labels with the same key, the lifecycle MUST use t
 
 For each process, the buildpack:
 
-- MUST specify a `type`. `type`:
+- MUST specify a `type`, which:
   - MUST NOT be identical to other process types provided by the same buildpack.
   - MUST only contain numbers, letters, and the characters ., _, and -.
 - MUST specify a `command` that is either:

--- a/buildpack.md
+++ b/buildpack.md
@@ -811,7 +811,9 @@ If multiple buildpacks define labels with the same key, the lifecycle MUST use t
 
 For each process, the buildpack:
 
-- MUST specify a `type` that is not identical to other process types provided by the same buildpack.
+- MUST specify a `type`. `type`:
+  - MUST NOT be identical to other process types provided by the same buildpack.
+  - MUST only contain numbers, letters, and the characters ., _, and -.
 - MUST specify a `command` that is either:
   - A command sequence that is valid when executed using the shell, if `args` is not specified.
   - A path to an executable or the file name of an executable in `$PATH`, if `args` is a list with zero or more elements.


### PR DESCRIPTION
Character restrictions in process type strings allow us to make process type symlinks on both linux and windows filesystems

Signed-off-by: Emily Casey <ecasey@vmware.com>

Character restrictions should have been included in [RFC 0045](https://github.com/buildpacks/rfcs/blob/main/text/0045-launcher-arguments.md). This was [discussed](https://github.com/buildpacks/rfcs/pull/84#discussion_r442380422) during the RFC approval process, and was mistakenly omitted from the final RFC & spec.