### PR TITLE
Clarify that both lifecycle and platform are programs

### DIFF
--- a/platform.md
+++ b/platform.md
@@ -1,9 +1,9 @@
 # Platform Interface Specification
 
 This document specifies how to process buildpack lifecycle steps to ensure compatibility
-of end-user tools.
+between end-user tools.
 
-Examples of a such end-user tools might include:
+Examples of tools implementing Platform Interface might include:
 
 1. A local CLI tool that uses buildpacks to create OCI images
 1. A plugin for a continuous integration service that uses buildpacks to create OCI images

--- a/platform.md
+++ b/platform.md
@@ -1,6 +1,6 @@
 # Platform Interface Specification
 
-This document specifies the interface between a lifecycle and a platform.
+This document specifies the interface between implementations of a `lifecycle` program and a `platform` program.
 
 A platform orchestrates a lifecycle to make buildpack functionality available to end-users such as application developers.
 

--- a/platform.md
+++ b/platform.md
@@ -1,10 +1,9 @@
 # Platform Interface Specification
 
-This document specifies the interface between implementations of a `lifecycle` program and a `platform` program.
+This document specifies how to process buildpack lifecycle steps to ensure compatibility
+of end-user tools.
 
-A platform orchestrates a lifecycle to make buildpack functionality available to end-users such as application developers.
-
-Examples of a platform might include:
+Examples of a such end-user tools might include:
 
 1. A local CLI tool that uses buildpacks to create OCI images
 1. A plugin for a continuous integration service that uses buildpacks to create OCI images


### PR DESCRIPTION
Specs are better when detailed and explicit. Like Linux is a platform, Google Cloud Platform is a platform. The use of the word `platform` with additional specifiers that narrow the context is unclear for new users.