### PR TITLE
Update build bom

### DIFF
--- a/platform.md
+++ b/platform.md
@@ -987,6 +987,10 @@ name = "<dependency name>"
 
 [build.bom.metadata]
 version = "<dependency version>"
+
+[build.bom.buildpack]
+id = "<buildpack ID>"
+version = "<buildpack version>"
 ```
 Where:
 - `tags` MUST contain all tag references to the exported app image


### PR DESCRIPTION
Add build.bom.buildpack to report.toml
    
The information included in the build BOM should have the same schema as the image BOM (io.buildpacks.build.metadata).