### PR TITLE
Add prepare phase for mixin and stack validation

### DIFF
--- a/platform.md
+++ b/platform.md
@@ -1058,7 +1058,7 @@ Where:
  mirrors = ["<mirror>", "<mirror>"]
  os = "<operating system>"
  arch = "<architecture>"
- reference = "<image reference>"
+ ref = "<image ref>"
  mixins = [ "<mixin name>" ]
 
 [build-image]

--- a/platform.md
+++ b/platform.md
@@ -308,6 +308,7 @@ Usage:
 ```
 /cnb/lifecycle/preparer \
   [-log-level <log-level>] \
+  [-run-image <run-image>] \
   [-stack-id <stack-id>] \
   [-stack-path <stack-path>]
 ```
@@ -316,6 +317,7 @@ Usage:
 | Input         | Environment Variable    | Default Value             | Description
 |---------------|-------------------------|---------------------------|----------------------
 | `<log-level>`  | `CNB_LOG_LEVEL`       | `info`                   | Log Level
+| `<run-image>`       | `CNB_RUN_IMAGE`  | resolved from `<stack>`   | Run image reference
 | `<stack-id>`   | `CNB_STACK_ID`        |                          | Chosen stack ID
 | `<stack-path>` | `CNB_STACK_PATH`      | `/cnb/stack.toml`        | Path to stack file (see [`stack.toml`](#stacktoml-toml)
 

--- a/platform.md
+++ b/platform.md
@@ -161,7 +161,7 @@ The stack ID:
 
 During the prepare phase, the stack properties of the new run-image MUST be compared to the stack properties of the previous run-image. If any of the following are true, the analysis MUST fail:
 * A mixin listed on the previous image does not exist on the new run-image
-* The operating system of the previous image does not matches the new run-image
+* The operating system of the previous image does not match the new run-image
 * The architecture of the previous image does not matches the new run-image
 
 During detection, the stack properties of the build image MUST be compared to the stack properties of the run-image. If any of the following are true, the analysis MUST fail:

--- a/platform.md
+++ b/platform.md
@@ -159,7 +159,7 @@ The stack ID:
 
 ### Stack Validation
 
-During the prepare phase, the stack properties of the new run-image MUST be compared to the stack properties of the previous run-image. If any of the following are true, the analysis MUST fail:
+During the prepare phase, the stack properties of the new run-image MUST be compared to the stack properties of the previous run-image. If any of the following are true, the prepare phase MUST fail:
 * A mixin listed on the previous image does not exist on the new run-image
 * The operating system of the previous image does not match the new run-image
 * The architecture of the previous image does not matches the new run-image

--- a/platform.md
+++ b/platform.md
@@ -226,7 +226,7 @@ However, mixins MAY consist of any changes that follow the [Compatibility Guaran
 
 #### Mixin Resolution
 
-During the prepare phase, a list of provided mixins MUST be retrived from the provided run-image. The analyzer should either fail or ignore the previous image if the run-image is missing any mixins that were present on the previous image.
+During the prepare phase, a list of provided mixins MUST be retrived from the provided run-image. The preparer should either fail or ignore the previous image if the run-image is missing any mixins that were present on the previous image.
 
 During detection, a list of required mixins MUST be resolved against a list of provided mixins.
 

--- a/platform.md
+++ b/platform.md
@@ -270,7 +270,7 @@ A single app image build* consists of the following phases:
 1. Export
 
 A platform MUST execute these phases either by invoking the following phase-specific lifecycle binaries in order:
-1. `/cnb/lifecycle/prepare`
+1. `/cnb/lifecycle/preparer`
 1. `/cnb/lifecycle/detector`
 1. `/cnb/lifecycle/analyzer`
 1. `/cnb/lifecycle/restorer`


### PR DESCRIPTION
Supersedes #172 

The `prepare` phase produces a `stack.toml` used by subsequent phases.