### PR TITLE
Clarify that launcher OR symlink is the entrypoint

### DIFF
--- a/platform.md
+++ b/platform.md
@@ -267,7 +267,7 @@ To rebase an app image a platform MUST execute the `/cnb/lifecycle/rebaser` or p
  
 #### Launch
 `/cnb/lifecycle/launcher` is responsible for launching user and buildpack provided processes in the correct execution environment.
-`/cnb/lifecycle/launcher` SHALL be the `ENTRYPOINT` for all app images.
+`/cnb/lifecycle/launcher`, or a symlink to it (see [exporter outputs](#outputs-4)), SHALL be the `ENTRYPOINT` for all app images.
 
 ### Usage
 


### PR DESCRIPTION
The current description is inaccurate as of platform api 0.4. 

Signed-off-by: Natalie Arellano <narellano@vmware.com>