### PR TITLE
Condense lifecycle exit codes

### DIFF
--- a/platform.md
+++ b/platform.md
@@ -319,9 +319,9 @@ Usage:
 | `11`      | Platform API incompatibility error
 | `12`      | Buildpack API incompatibility error
 | `1-10`, `13-19` | Generic lifecycle errors
-| `100`     | All buildpacks groups have failed to detect w/o error
-| `101`     | All buildpack groups have failed to detect and at least one buildpack has errored
-| `102-199` | Detection-specific lifecycle errors
+| `20`     | All buildpacks groups have failed to detect w/o error
+| `21`     | All buildpack groups have failed to detect and at least one buildpack has errored
+| `22-29` | Detection-specific lifecycle errors
 
 The lifecycle:
 - SHALL detect a single group from `<order>` and write it to `<group>` using the [detection process](buildpack.md#phase-1-detection) outlined in the Buildpack Interface Specification
@@ -379,7 +379,7 @@ Usage:
 | `11`      | Platform API incompatibility error
 | `12`      | Buildpack API incompatibility error
 | `1-10`, `13-19` | Generic lifecycle errors
-| `40-59` | Analysis-specific lifecycle errors
+| `30-39` | Analysis-specific lifecycle errors
 
 - The lifecycle MUST write [analysis metadata](#analyzedtoml-toml) to `<analyzed>` if `<image>` is accessible.
 - **If** `<skip-layers>` is `true` the lifecycle MUST NOT perform layer analysis.
@@ -436,7 +436,7 @@ Usage:
 | `11`      | Platform API incompatibility error
 | `12`      | Buildpack API incompatibility error
 | `1-10`, `13-19` | Generic lifecycle errors
-| `60-79` | Restoration-specific lifecycle errors
+| `40-49` | Restoration-specific lifecycle errors
 
 ##### Layer restoration
 For each layer metadata file found in the `<layers>` directory, the lifecycle:
@@ -485,8 +485,8 @@ Usage:
 | `11`      | Platform API incompatibility error
 | `12`      | Buildpack API incompatibility error
 | `1-10`, `13-19` | Generic lifecycle errors
-| `401`     | Buildpack build error
-| `400`, `402-499`|  Build-specific lifecycle errors
+| `51`     | Buildpack build error
+| `50`, `52-59`|  Build-specific lifecycle errors
 
 - The lifecycle SHALL execute all buildpacks in the order defined in `<group>` according process outlined in the [Buildpack Interface Specification](buildpack.md).
 - The lifecycle SHALL add all invoked buildpacks to`<layers>/config/metadata.toml`.
@@ -558,7 +558,7 @@ Usage:
 | `11`      | Platform API incompatibility error
 | `12`      | Buildpack API incompatibility error
 | `1-10`, `13-19` | Generic lifecycle errors
-| `100-119`|  Export-specific lifecycle errors
+| `60-69`|  Export-specific lifecycle errors
 
 - The lifecycle SHALL write the same app image to each `<image>` tag
 - The app image:
@@ -644,11 +644,11 @@ Outputs produced by `creator` are identical to those produced by `exporter`, wit
 | `11`      | Platform API incompatibility error
 | `12`      | Buildpack API incompatibility error
 | `1-10`, `13-19` | Generic lifecycle errors
-| `20-39`|  Detection-specific lifecycle errors
-| `40-59`|  Analysis-specific lifecycle errors
-| `60-79`|  Restoration-specific lifecycle errors
-| `80-99`|  Build-specific lifecycle errors
-| `100-119`|  Export-specific lifecycle errors
+| `20-29`|  Detection-specific lifecycle errors
+| `30-39`|  Analysis-specific lifecycle errors
+| `40-49`|  Restoration-specific lifecycle errors
+| `50-59`|  Build-specific lifecycle errors
+| `60-69`|  Export-specific lifecycle errors
 
 
 #### `rebaser`
@@ -694,7 +694,7 @@ Usage:
 | `11`      | Platform API incompatibility error
 | `12`      | Buildpack API incompatibility error
 | `1-10`, `13-19` | Generic lifecycle errors
-| `180-199`|  Rebase-specific lifecycle errors
+| `70-79`|  Rebase-specific lifecycle errors
 
 - The lifecycle SHALL write the same app image to each `<image>` tag
 - The rebased app image SHALL be identical to `<image>`, with the following modifications:
@@ -754,7 +754,7 @@ If the launcher errors before executing the process it will have one of the foll
 |-----------|-------|
 | `11`      | Platform API incompatibility error
 | `12`      | Buildpack API incompatibility error
-| `200-219`|  Launch-specific lifecycle errors
+| `80-89`|  Launch-specific lifecycle errors
 
 Otherwise, the exit code shall be the exit code of the launched process.
 

--- a/platform.md
+++ b/platform.md
@@ -318,7 +318,7 @@ Usage:
 | `0`       | Success
 | `11`      | Platform API incompatibility error
 | `12`      | Buildpack API incompatibility error
-| `1-10`, `13-99` | Generic lifecycle errors
+| `1-10`, `13-19` | Generic lifecycle errors
 | `100`     | All buildpacks groups have failed to detect w/o error
 | `101`     | All buildpack groups have failed to detect and at least one buildpack has errored
 | `102-199` | Detection-specific lifecycle errors
@@ -378,8 +378,8 @@ Usage:
 | `0`       | Success
 | `11`      | Platform API incompatibility error
 | `12`      | Buildpack API incompatibility error
-| `1-10`, `13-99` | Generic lifecycle errors
-| `200-299` | Analysis-specific lifecycle errors
+| `1-10`, `13-19` | Generic lifecycle errors
+| `40-59` | Analysis-specific lifecycle errors
 
 - The lifecycle MUST write [analysis metadata](#analyzedtoml-toml) to `<analyzed>` if `<image>` is accessible.
 - **If** `<skip-layers>` is `true` the lifecycle MUST NOT perform layer analysis.
@@ -435,8 +435,8 @@ Usage:
 | `0`       | Success
 | `11`      | Platform API incompatibility error
 | `12`      | Buildpack API incompatibility error
-| `1-10`, `13-99` | Generic lifecycle errors
-| `300-399` | Restoration-specific lifecycle errors
+| `1-10`, `13-19` | Generic lifecycle errors
+| `60-79` | Restoration-specific lifecycle errors
 
 ##### Layer restoration
 For each layer metadata file found in the `<layers>` directory, the lifecycle:
@@ -484,7 +484,7 @@ Usage:
 | `0`       | Success
 | `11`      | Platform API incompatibility error
 | `12`      | Buildpack API incompatibility error
-| `1-10`, `13-99` | Generic lifecycle errors
+| `1-10`, `13-19` | Generic lifecycle errors
 | `401`     | Buildpack build error
 | `400`, `402-499`|  Build-specific lifecycle errors
 
@@ -557,8 +557,8 @@ Usage:
 | `0`       | Success
 | `11`      | Platform API incompatibility error
 | `12`      | Buildpack API incompatibility error
-| `1-10`, `13-99` | Generic lifecycle errors
-| `500-599`|  Export-specific lifecycle errors
+| `1-10`, `13-19` | Generic lifecycle errors
+| `100-119`|  Export-specific lifecycle errors
 
 - The lifecycle SHALL write the same app image to each `<image>` tag
 - The app image:
@@ -643,12 +643,12 @@ Outputs produced by `creator` are identical to those produced by `exporter`, wit
 | `0`       | Success
 | `11`      | Platform API incompatibility error
 | `12`      | Buildpack API incompatibility error
-| `1-10`, `13-99` | Generic lifecycle errors
-| `100-199`|  Detection-specific lifecycle errors
-| `200-299`|  Analysis-specific lifecycle errors
-| `300-399`|  Restoration-specific lifecycle errors
-| `400-499`|  Build-specific lifecycle errors
-| `500-599`|  Export-specific lifecycle errors
+| `1-10`, `13-19` | Generic lifecycle errors
+| `20-39`|  Detection-specific lifecycle errors
+| `40-59`|  Analysis-specific lifecycle errors
+| `60-79`|  Restoration-specific lifecycle errors
+| `80-99`|  Build-specific lifecycle errors
+| `100-119`|  Export-specific lifecycle errors
 
 
 #### `rebaser`
@@ -693,8 +693,8 @@ Usage:
 | `0`       | Success
 | `11`      | Platform API incompatibility error
 | `12`      | Buildpack API incompatibility error
-| `1-10`, `13-99` | Generic lifecycle errors
-| `600-699`|  Rebase-specific lifecycle errors
+| `1-10`, `13-19` | Generic lifecycle errors
+| `180-199`|  Rebase-specific lifecycle errors
 
 - The lifecycle SHALL write the same app image to each `<image>` tag
 - The rebased app image SHALL be identical to `<image>`, with the following modifications:
@@ -754,7 +754,7 @@ If the launcher errors before executing the process it will have one of the foll
 |-----------|-------|
 | `11`      | Platform API incompatibility error
 | `12`      | Buildpack API incompatibility error
-| `700-799`|  Launch-specific lifecycle errors
+| `200-219`|  Launch-specific lifecycle errors
 
 Otherwise, the exit code shall be the exit code of the launched process.
 


### PR DESCRIPTION
When the exit code exceeds 255 it is expressed modulo 256 when surfaced in bash, which can be confusing.

This PR attempts to avoid "special" exit codes as described here: https://tldp.org/LDP/abs/html/exitcodes.html

Lifecycle issue: https://github.com/buildpacks/lifecycle/issues/502