### PR TITLE
Explicitly ban the use of special layer names in the BP spec

### DIFF
--- a/buildpack.md
+++ b/buildpack.md
@@ -487,7 +487,8 @@ Correspondingly, each `/bin/build` executable:
 - MAY modify or delete any existing `<layers>/<layer>.toml` files.
 - MAY create new `<layers>/<layer>` directories.
 - MAY create new `<layers>/<layer>.toml` files.
-- MAY name any new `<layers>/<layer>` directories without restrictions except those imposed by the filesystem.
+- MAY name any new `<layers>/<layer>` directories without restrictions except those imposed by the filesystem and the ones noted below.
+- MUST NOT create `<layers>/<layer>` directories with `<layer>` names `build`, `launch` or `store`.
 - SHOULD NOT use the `<app>` directory to store provided dependencies.
 
 #### Unmet Buildpack Plan Entries


### PR DESCRIPTION
This modifies the spec to prohibit buildpacks from creating layers with name `build`, `launch` or `store`. This is to acoid confusions with special metadata files like build.toml etc. which may conflict with the layer metadata files.

In the future, we should create an RFC to decouple these directories/files entirely so that we don't encounter such issues in the future when we want to add additional special metadata files.

Fixes #200 