### PR TITLE
Added new buildpack.toml fields from RFC-0070

### DIFF
--- a/buildpack.md
+++ b/buildpack.md
@@ -1017,7 +1017,7 @@ If an `order` is specified, then `stacks` MUST NOT be specified.
 The `[[buildpack.licenses]]` table is optional and MAY contain a list of buildpack licenses where:
 
 - `type` - This MAY use the SPDX 2.1 license expression, but is not limited to identifiers in the SPDX Licenses List.
-- `uri` - If this buildpack is using a nonstandard license, then this key MAY be specified in lieu of or in addition to type to point to the license.
+- `uri` - If this buildpack is using a nonstandard license, then this key MAY be specified in lieu of or in addition to `type` to point to the license.
 
 #### Buildpack Implementations
 

--- a/buildpack.md
+++ b/buildpack.md
@@ -968,6 +968,12 @@ name = "<buildpack name>"
 version = "<buildpack version>"
 homepage = "<buildpack homepage>"
 clear-env = false
+description = "<buildpack description>"
+keywords = [ "<string>" ]
+
+[[buildpack.licenses]]
+type = "<string>"
+uri = "<uri>"
 
 [[order]]
 [[order.group]]
@@ -1005,6 +1011,13 @@ If an `order` is specified, then `stacks` MUST NOT be specified.
  - MUST be in form `<major>.<minor>` or `<major>`, where `<major>` is equivalent to `<major>.0`
  - MUST describe the implemented buildpack API.
  - SHOULD indicate the lowest compatible `<minor>` if buildpack behavior is consistent with multiple `<minor>` versions of a given `<major>`
+
+**The buildpack licenses:**
+
+The `[[buildpack.licenses]]` table is optional and MAY contain a list of buildpack licenses where:
+
+- `type` - This MAY use the SPDX 2.1 license expression, but is not limited to identifiers in the SPDX Licenses List.
+- `uri` - If this buildpack is using a nonstandard license, then this key MAY be specified in lieu of or in addition to type to point to the license.
 
 #### Buildpack Implementations
 


### PR DESCRIPTION
Implements the [spec changes described in RFC-0070](https://github.com/buildpacks/rfcs/blob/main/text/0070-new-buildpack-toml-keys.md#spec-changes).

Fixes #181