### PR TITLE
relax mixin contract for buildpacks

### DIFF
--- a/buildpack.md
+++ b/buildpack.md
@@ -320,7 +320,18 @@ The lifecycle MAY execute each `/bin/detect` within a group in parallel.
 
 The lifecycle MUST run `/bin/detect` for all buildpacks in a group in a container using common stack with a common set of mixins.
 The lifecycle MUST fail detection if any of those buildpacks does not list that stack in `buildpack.toml`.
-The lifecycle MUST fail detection if any of those buildpacks specifies a mixin associated with that stack in `buildpack.toml` that is unavailable in the container.
+The lifecycle MUST fail detection if any of those buildpacks specifies a mixin associated with that stack in `buildpack.toml` that is not satisfied, see [Mixin Satisfaction](#mixin-satisfaction) below.
+
+#### Mixin Satisfaction
+A buildpack's mixin requirements must be satisfied by the stack in one of the following scenarios.
+
+1) the stack provides the mixin `run:<mixin>` and the buildpack requires `run:<mixin>`
+2) the stack provides the mixin `build:<mixin>` and the buildpack requires `build:<mixin>`
+3) the stack provides the mixin `<mixin>` and the buildpack requires `<mixin>`
+4) the stack provides the mixin `<mixin>` and the buildpack requires `build:<mixin>`
+5) the stack provides the mixin `<mixin>` and the buildpack requires `run:<mixin>`
+6) the stack provides the mixin `<mixin>` and the buildpack requires both `run:<mixin>` and `build:<mixin>`
+7) the stack provides the mixins `build:<mixin>` and `run:<mixin>` the buildpack requires `<mixin>`
 
 #### Order Resolution
 

--- a/platform.md
+++ b/platform.md
@@ -206,6 +206,7 @@ A mixin name MUST only contain a `:` character as part of an optional stage spec
 
 A mixin prefixed with the `build:` stage specifier only affects the build image and does not need to be specified on the run image.
 A mixin prefixed with the `run:` stage specifier only affects the run image and does not need to be specified on the build image.
+A mixin WITHOUT a `build:` or `run:` prefix affects both the build and the run images.
 
 A platform MAY support any number of mixins for a given stack in order to support application code or buildpacks that require those mixins.
 

--- a/platform.md
+++ b/platform.md
@@ -206,7 +206,6 @@ A mixin name MUST only contain a `:` character as part of an optional stage spec
 
 A mixin prefixed with the `build:` stage specifier only affects the build image and does not need to be specified on the run image.
 A mixin prefixed with the `run:` stage specifier only affects the run image and does not need to be specified on the build image.
-A mixin WITHOUT a `build:` or `run:` prefix affects both the build and the run images.
 
 A platform MAY support any number of mixins for a given stack in order to support application code or buildpacks that require those mixins.
 


### PR DESCRIPTION
This only addresses regular buildpacks and leaves stack buildpacks out until we have a better idea about how they will fit into the spec. 

Solves part of #149 
New issue for stackpacks work #211 

Signed-off-by: dwillist <dthornton@vmware.com>