### PR TITLE
Update platform 0.7 to reflect pause in mixin validation

### DIFF
--- a/platform.md
+++ b/platform.md
@@ -317,8 +317,8 @@ Usage:
 - **If** `<daemon>` is `true`, `<previous-image>`, if provided, MUST be either a valid image reference or an imageID
 - **If** `<run-image>` is not provided by the platform the lifecycle MUST [resolve](#run-image-resolution) the run image from the contents of `stack` or fail if `stack` does not contain a valid run image.
 - The lifecycle MUST accept valid references to non-existent images without error.
-- The lifecycle MUST fail if the stack ID of the `<run-image>` does not match `<stack-id>`
 - The lifecycle MUST ensure registry write access to `<image>`, `<cache-image>` and any provided `<tag>`s.
+- The lifecycle MUST ensure registry read access to `<previous-image>` and `<run-image>`.
 - The lifecycle MUST write [analysis metadata](#analyzedtoml-toml) to `<analyzed>`, where:
   - `image` MUST describe the `<previous-image>`
 

--- a/platform.md
+++ b/platform.md
@@ -317,12 +317,9 @@ Usage:
 - **If** `<daemon>` is `false`, `<previous-image>`, if provided,  MUST be a valid image reference.
 - **If** `<daemon>` is `true`, `<previous-image>`, if provided, MUST be either a valid image reference or an imageID.
 - **If** `<run-image>` is not provided by the platform the lifecycle MUST [resolve](#run-image-resolution) the run image from the contents of `stack` or fail if `stack` does not contain a valid run image.
-- The lifecycle MUST accept valid references to non-existent `<previous-image>` and `<image>` without error.
+- The lifecycle MUST accept valid references to non-existent `<previous-image>`, `<cache-image>`, and `<image>` without error.
 - The lifecycle MUST ensure registry write access to `<image>`, `<cache-image>` and any provided `<tag>`s.
-- The lifecycle MUST ensure registry read access to `<previous-image>` and `<run-image>`.
-- The lifecycle MUST write [analysis metadata](#analyzedtoml-toml) to `<analyzed>`, where:
-  - `image` MUST describe the `<previous-image>`
-  - `run-image` MUST describe the `<run-image>`
+- The lifecycle MUST ensure registry read access to `<previous-image>`, `<cache-image>`, and `<run-image>`.
 
 ##### Outputs
 | Output             | Description
@@ -340,12 +337,9 @@ Usage:
 | `1-10`, `13-99` | Generic lifecycle errors
 | `30-39` | Analysis-specific lifecycle errors
 
-- The lifecycle MUST write [analysis metadata](#analyzedtoml-toml) to `<analyzed>`.
 - The lifecycle MUST write [analysis metadata](#analyzedtoml-toml) to `<analyzed>`, where:
- - **If** the `<previous-image>` is compatible with the `<run-image>` `previous-image` MUST describe `<previous-image>`.  `<previous-image>` is compatible with `<run-image>` if:
-   - The stack IDs match
-   - `<run-image>` `mixins` are a superset of `<previous-image>` mixins
- - **Else** the lifecycle MUST omit `previous-image.reference` and `previous-image.metadata`
+  - `image` MUST describe the `<previous-image>`, if accessible
+  - `run-image` MUST describe the `<run-image>`
 
 #### `detector`
 The platform MUST execute `detector` in the **build environment**
@@ -548,7 +542,7 @@ Usage:
 - At least one `<image>` must be provided
 - Each `<image>` MUST be a valid tag reference
 - **If** `<daemon>` is `false` and more than one `<image>` is provided they MUST refer to the same registry
-- **If** `<run-image>` is not provided by the platform the value will be [resolved](#run-image-resolution) from the contents of `stack`
+- The <run-image>` will be read from [`analyzed.toml`](#analyzedtoml-toml)
 
 ##### Outputs
 | Output             | Description

--- a/platform.md
+++ b/platform.md
@@ -322,6 +322,7 @@ Usage:
 - The lifecycle MUST ensure registry read access to `<previous-image>` and `<run-image>`.
 - The lifecycle MUST write [analysis metadata](#analyzedtoml-toml) to `<analyzed>`, where:
   - `image` MUST describe the `<previous-image>`
+  - `run-image` MUST describe the `<run-image>`
 
 ##### Outputs
 | Output             | Description
@@ -519,7 +520,6 @@ Usage:
   [-process-type <process-type> ] \
   [-project-metadata <project-metadata> ] \
   [-report <report> ] \
-  [-run-image <run-image> | -image <run-image> ] \ # -image is Deprecated
   [-uid <uid> ] \
   <image> [<image>...]
 ```
@@ -542,7 +542,6 @@ Usage:
 | `<process-type>`    | `CNB_PROCESS_TYPE`         |                     | Default process type to set in the exported image
 | `<project-metadata>`| `CNB_PROJECT_METADATA_PATH`| `<layers>/project-metadata.toml` | Path to a project metadata file (see [`project-metadata.toml`](#project-metadatatoml-toml)
 | `<report>`          | `CNB_REPORT_PATH`          | `<layers>/report.toml`    | Path to report (see [`report.toml`](#reporttoml-toml)
-| `<run-image>`       | `CNB_RUN_IMAGE`            | resolved from `<stack>`   | Run image reference
 | `<uid>`             | `CNB_USER_ID`              |                     | UID of the stack `User`
 | `<layers>/config/metadata.toml` | | | Build metadata (see [`metadata.toml`](#metadatatoml-toml)
 
@@ -569,9 +568,9 @@ Usage:
 
 - The lifecycle SHALL write the same app image to each `<image>` tag
 - The app image:
-    - MUST be an extension of the `<run-image>`
+    - MUST be an extension of the `run-image` in [`analyzed.toml`](#analyzedtoml-toml)
       - All run-image layers SHALL be preserved
-      - All run-image config values SHALL be preserved unless this conflict with another requirement
+      - All run-image config values SHALL be preserved unless this conflicts with another requirement
     - MUST contain all buildpack-provided launch layers as determined by the [Buildpack Interface Specfication](buildpack.md)
     - MUST contain one or more app layers as determined by the [Buildpack Interface Specfication](buildpack.md)
     - MUST contain one or more launcher layers that include:
@@ -883,6 +882,9 @@ For more information on build reproducibility see [https://reproducible-builds.o
 
 [metadata]
 # layer metadata
+
+[run-image]
+  reference = "<image reference>"
 ```
 
 Where:

--- a/platform.md
+++ b/platform.md
@@ -313,10 +313,11 @@ Usage:
 
 -`<image>` MUST be a valid image reference
 - **If** the platform provides one or more `<tag>` inputs, each `<tag>` MUST be a valid image reference.
-- **If** `<daemon>` is `false`, `<previous-image>`, if provided,  MUST be a valid image reference
-- **If** `<daemon>` is `true`, `<previous-image>`, if provided, MUST be either a valid image reference or an imageID
+- **If** `<daemon>` is `false` and the platform provides one or more `<tag>` inputs, each `<tag>` MUST refer to the same registry as `<image>`.
+- **If** `<daemon>` is `false`, `<previous-image>`, if provided,  MUST be a valid image reference.
+- **If** `<daemon>` is `true`, `<previous-image>`, if provided, MUST be either a valid image reference or an imageID.
 - **If** `<run-image>` is not provided by the platform the lifecycle MUST [resolve](#run-image-resolution) the run image from the contents of `stack` or fail if `stack` does not contain a valid run image.
-- The lifecycle MUST accept valid references to non-existent images without error.
+- The lifecycle MUST accept valid references to non-existent `<previous-image>` and `<image>` without error.
 - The lifecycle MUST ensure registry write access to `<image>`, `<cache-image>` and any provided `<tag>`s.
 - The lifecycle MUST ensure registry read access to `<previous-image>` and `<run-image>`.
 - The lifecycle MUST write [analysis metadata](#analyzedtoml-toml) to `<analyzed>`, where:


### PR DESCRIPTION
* Add back `-cache-image` to analyzer so that we can check read/write access
* Remove `-order` from analyzer as it is no longer needed
* Put `analyzed.toml` and `stack.toml` back to the old schema
* Remove `-analyzed` from detector as it is no longer needed