### PR TITLE
Updates buildpack API version in spec and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,6 @@ When the specification refers to a path in the context of an OCI layer tar (e.g.
 
 These documents currently specify:
 
-- Buildpack API: `0.6`
+- Buildpack API: `0.7`
 - Distribution API: `0.2`
 - Platform API: `0.6`

--- a/buildpack.md
+++ b/buildpack.md
@@ -84,7 +84,7 @@ The `ENTRYPOINT` of the OCI image contains logic implemented by the lifecycle th
       - [Build Plan (TOML) `requires.version` Key](#build-plan-toml-requiresversion-key)
 
 ## Buildpack API Version
-This document specifies Buildpack API version `0.5`
+This document specifies Buildpack API version `0.7`
 
 Buildpack API versions:
  - MUST be in form `<major>.<minor>` or `<major>`, where `<major>` is equivalent to `<major>.0`


### PR DESCRIPTION
Updates buildpack API version to 0.7 in README and platform spec.

Signed-off-by: Emily Casey <ecasey@vmware.com>