### PR TITLE
Distribution Specs (v3) - Buildpacks Artifact Format

### DIFF
--- a/distribution.md
+++ b/distribution.md
@@ -31,9 +31,13 @@ Distribution API versions:
 
 A buildpackage is a buildpack packaged for distribution.
 
-A buildpackage MUST exist as either an OCI image on an image registry, an OCI image in a Docker daemon, or a `.cnb` file.
+A buildpackage MUST exist in one of the following formats:
 
-A `.cnb` file MUST be an uncompressed tar archive containing an OCI image. Its file name SHOULD end in `.cnb`.
+* An OCI Image on an image registry.
+* An OCI Image in a Docker daemon.
+* An uncompressed tar archive in [oci-layout](https://github.com/opencontainers/image-spec/blob/main/image-layout.md) format.
+  * The file SHOULD have the extension `.cnb`.
+
 
 [†](README.md#linux-only)For Linux buildpackages, all FS layers MUST be buildpack layers.
 
@@ -116,5 +120,3 @@ The following labels MUST be set in the buildpack image(through the image config
 The buildpack ID and version MUST match a buildpack provided by a layer blob.
 
 For a buildpackage to be valid, each `buildpack.toml` describing a buildpack implementation MUST have all listed targets.
-
-For each listed target, all associated buildpacks MUST be a candidate for detection when the entrypoint buildpack ID and version are selected.

--- a/distribution.md
+++ b/distribution.md
@@ -70,12 +70,6 @@ The following labels MUST be set in the buildpack image(through the image config
   "name": "<buildpack name>",
   "version": "<entrypoint buildpack version>",
   "homepage": "<buildpack home page",
-  "targets": [
-    {
-      "os": "<build-image os>",
-      "architecture": "<architecture>"
-    }
-  ]
 }
 ```
 
@@ -103,12 +97,6 @@ The following labels MUST be set in the buildpack image(through the image config
   "<inner buildpack>": {
     "<inner buildpack version>": {
       "api": "<buildpack API>",
-      "targets" : [
-        {
-          "os": "<os buildpack supports>",
-          "architecture": "<underlying architecture>",
-        }
-      ],
       "layerDiffID": "<diff-ID>",
       "homepage": "<buildpack homepage>",
       "name": "<buildpack name>",      

--- a/distribution.md
+++ b/distribution.md
@@ -49,14 +49,14 @@ A buildpack MUST contain a `buildpack.toml` file at its root directory.
 
 #### Labels
 
-For each buildpack layer, the buildpack ID and the buildpack version MUST be provided in `io.buildpacks.buildpack.layers`
+For each buildpack layer, the buildpack ID and the buildpack version MUST be provided in `io.buildpacks.buildpackage.layers`
 
 The following labels MUST be set in the buildpack image(through the image config's `Labels` field):
 
 | Label             | Description | 
 | --------          | -------- 
-| `io.buildpacks.buildpack.metadata`     | A JSON object representing Buildpack Metadata   |
-| `io.builpacks.buildpack.layers`| A JSON object representing the buildpack layers |
+| `io.buildpacks.buildpackage.metadata`     | A JSON object representing Buildpack Metadata   |
+| `io.builpacks.buildpackage.layers`| A JSON object representing the buildpack layers |
 
 
 `io.buildpacks.buildpackage.metadata` (JSON)
@@ -69,7 +69,7 @@ The following labels MUST be set in the buildpack image(through the image config
 }
 ```
 
-`io.buildpacks.buildpack.layers` (JSON)
+`io.buildpacks.buildpackage.layers` (JSON)
 ```json
 {
   "<buildpack ID>": {

--- a/distribution.md
+++ b/distribution.md
@@ -1,6 +1,6 @@
 # Distribution Specification
 
-This document specifies the artifact format, delivery mechanism, and order resolution process for buildpacks.
+This document specifies the artifact format and the delivery mechanism for the buildpacks core components.
 
 
 ## Table of Contents
@@ -10,8 +10,11 @@ This document specifies the artifact format, delivery mechanism, and order resol
   - [Table of Contents](#table-of-contents)
   - [Distribution API Version](#distribution-api-version)
   - [Artifact Format](#artifact-format)
-    - [Buildpack](#buildpack)
     - [Buildpackage](#buildpackage)
+    - [Lifecycle](#lifecycle)
+    - [Build Image](#build-image)
+    - [Run Image](#run-image)
+    - [Builder Image](#builder-image)
 
 ## Distribution API Version
 
@@ -20,14 +23,13 @@ This document specifies Distribution API version `0.3`.
 Distribution API versions:
  - MUST be in form `<major>.<minor>` or `<major>`, where `<major>` is equivalent to `<major>.0`
  - When `<major>` is greater than `0` increments to `<minor>` SHALL exclusively indicate additive changes
+ - Each Distributable artifact MUST contain the label `io.buildpacks.distribution.api` denoting the distribution API
 
 ## Artifact Format
 
-### Buildpack
-
-A buildpack MUST contain a [`buildpack.toml`](buildpack.md#buildpacktoml-toml) file at its root directory.
-
 ### Buildpackage
+
+A buildpackage is a buildpack packaged for distribution.
 
 A buildpackage MUST exist as either an OCI image on an image registry, an OCI image in a Docker daemon, or a `.cnb` file.
 
@@ -37,35 +39,82 @@ A `.cnb` file MUST be an uncompressed tar archive containing an OCI image. Its f
 
 [‡](README.md#windows-only)For Windows buildpackages, all FS layers MUST be either buildpack or OS layers.
 
-Each buildpack layer blob MUST contain a single buildpack at the following file path:
+Each buildpack layer blob MUST contain a single [buildpack](./buildpack.md) at the following file path:
 
 ```
 /cnb/buildpacks/<buildpack ID>/<buildpack version>/
 ```
 
-A buildpack ID, buildpack version, and at least one stack MUST be provided in the OCI image config as a Label.
+A buildpack MUST contain a `buildpack.toml` file at its root directory.
 
-Label: `io.buildpacks.buildpackage.metadata`
+#### Labels
+
+For each buildpack layer, the buildpack ID and the buildpack version MUST be provided in `io.buildpacks.buildpack.layers`
+
+The following labels MUST be set in the buildpack image(through the image config's `Labels` field):
+
+| Label             | Description | 
+| --------          | -------- 
+| `io.buildpacks.buildpack.metadata`     | A JSON object representing Buildpack Metadata   |
+| `io.builpacks.buildpack.layers`| A JSON object representing the buildpack layers |
+
+
+`io.buildpacks.buildpackage.metadata` (JSON)
 ```json
 {
   "id": "<entrypoint buildpack ID>",
+  "name": "<buildpack name>",
   "version": "<entrypoint buildpack version>",
-  "stacks": [
+  "homepage": "<buildpack home page",
+  "targets": [
     {
-      "id": "<stack ID>",
-      "mixins": ["<mixin name>"]
+      "os": "<build-image os>",
+      "architecture": "<architecture>"
     }
   ]
 }
 ```
 
+`io.buildpacks.buildpack.layers` (JSON)
+```json
+{
+  "<buildpack ID>": {
+    "<buildpack version>": {
+      "api": "<buildpack API>",
+      "order": [
+        {
+          "group": [
+            {
+              "id": "<inner buildpack ID>",
+              "version": "<inner buildpack version>"
+            }
+          ]
+        }
+      ],
+      "layerDiffID": "<diff-ID>",
+      "homepage": "<buildpack homepage>",
+      "name": "<buildpack name>",
+    }
+  },
+  "<inner buildpack>": {
+    "<inner buildpack version>": {
+      "api": "<buildpack API>",
+      "targets" : [
+        {
+          "os": "<os buildpack supports>",
+          "architecture": "<underlying architecture>",
+        }
+      ],
+      "layerDiffID": "<diff-ID>",
+      "homepage": "<buildpack homepage>",
+      "name": "<buildpack name>",      
+    }
+  }
+}
+```
+
 The buildpack ID and version MUST match a buildpack provided by a layer blob.
 
-For a buildpackage to be valid, each `buildpack.toml` describing a buildpack implementation MUST have all listed stacks.
+For a buildpackage to be valid, each `buildpack.toml` describing a buildpack implementation MUST have all listed targets.
 
-For each listed stack, all associated buildpacks MUST be a candidate for detection when the entrypoint buildpack ID and version are selected.
-
-Each stack ID MUST only be present once.
-For a given stack, the `mixins` list MUST enumerate mixins such that no included buildpacks are missing a mixin for the stack.
-
-Fewer stack entries as well as additional mixins for a stack entry MAY be specified.
+For each listed target, all associated buildpacks MUST be a candidate for detection when the entrypoint buildpack ID and version are selected.

--- a/distribution.md
+++ b/distribution.md
@@ -11,10 +11,6 @@ This document specifies the artifact format and the delivery mechanism for the b
   - [Distribution API Version](#distribution-api-version)
   - [Artifact Format](#artifact-format)
     - [Buildpackage](#buildpackage)
-    - [Lifecycle](#lifecycle)
-    - [Build Image](#build-image)
-    - [Run Image](#run-image)
-    - [Builder Image](#builder-image)
 
 ## Distribution API Version
 


### PR DESCRIPTION
This PR initiates spec'ing the new distribution API version (version 3).  

We envision the new distribution API would consist the artifact format and the delivery mechanism for the buildpacks core components, which include:

- Buildpackage
- Lifecycle
- Build Image
- Run Image

There is also a plan of include "Builder" specification in the new distribution spec, which would in-turn just reference the above mentioned components.

The entire process would be broken down into separate PRs (each one would specify a single component!)

This PR provides the artifact format for the Buildpacks.