### PR TITLE
Clarify buildpack API must be u64 numbers

### DIFF
--- a/buildpack.md
+++ b/buildpack.md
@@ -88,6 +88,7 @@ This document specifies Buildpack API version `0.7`
 
 Buildpack API versions:
  - MUST be in form `<major>.<minor>` or `<major>`, where `<major>` is equivalent to `<major>.0`
+ - `<major>` and `<minor>` MUST only contain numbers (unsigned 64 bit integer)
  - When `<major>` is greater than `0` increments to `<minor>` SHALL exclusively indicate additive changes
 
 ## Buildpack Interface


### PR DESCRIPTION
Currently the spec doesn't state what <major> and <minor> are expected to be.

I am proposing that we scope them to only contain numbers which seems to be what the lifecycle is already expecting:

https://github.com/buildpacks/lifecycle/blob/a7428a55c2a14d8a37e84285b95dc63192e3264e/api/version.go#L13-L16

Going beyond specifying they should be numbers, I also want to specify "unsigned 64 bit" integer which further bounds api versions to be greater than (or equal to) zero and less than (or equal to) 1,844,674,4073,709,551,615.

