### PR TITLE
Distribution Spec (v3) - Build Image Artifact format

### DIFF
--- a/distribution.md
+++ b/distribution.md
@@ -181,7 +181,7 @@ The Build Image SHOULD contain the following configurations:
 
 The Build Image MUST contain the following Environment Variables:
 
-* Image Config's `config.Env` field MUST have the environment variable `CNB_USER_ID` set to the user UID/SID of the user specified in the `User` field.
+* Image Config's `config.Env` field MUST have the environment variable `CNB_USER_ID` set to the user [†](README.md#operating-system-conventions)UID/[‡](README.md#operating-system-conventions)SID of the user specified in the `User` field.
 * Image Config's `config.Env` field MUST have the environment variable `CNB_GROUP_ID` set to the primary group GID/SID of the user specified in the `User` field.
 * Image Config's `config.Env` field MUST have the environment variable `PATH` set to a valid set of paths or explicitly set to empty (`PATH=`).
 

--- a/distribution.md
+++ b/distribution.md
@@ -11,12 +11,8 @@ This document specifies the artifact format and the delivery mechanism for the b
   - [Distribution API Version](#distribution-api-version)
   - [Artifact Format](#artifact-format)
     - [Buildpackage](#buildpackage)
-<<<<<<< HEAD
     - [Lifecycle](#lifecycle)
-=======
     - [Build Image](#build-image)
->>>>>>> feat: build-image distribution spec
-
 ## Distribution API Version
 
 This document specifies Distribution API version `0.3`.

--- a/distribution.md
+++ b/distribution.md
@@ -161,7 +161,7 @@ Where:
       * should only contain APIs that correspond to a spec release
 ### Build Image
 
-The following defines how a `build-image` SHOULD be packaged for distribution as an OCI Image. The `build-image` is the component that provides the base image from which the build environment is constructed.
+The following defines how a build image SHOULD be packaged for distribution as an OCI Image. The build image is the component that provides the base image from which the build environment is constructed.
 
 The image configuration refers to the OCI Image configuration as mentioned [here](https://github.com/opencontainers/image-spec/blob/main/config.md#properties).
 
@@ -183,7 +183,7 @@ The Build Image MUST contain the following Environment Variables:
 
 * Image Config's `config.Env` field MUST have the environment variable `CNB_USER_ID` set to the user UID/SID of the user specified in the `User` field.
 * Image Config's `config.Env` field MUST have the environment variable `CNB_GROUP_ID` set to the primary group GID/SID of the user specified in the `User` field.
-* Image Config's `config.Env` field MUST have the environment variable `PATH` set to a valid set of paths or explicitly set to empty. (`PATH=`).
+* Image Config's `config.Env` field MUST have the environment variable `PATH` set to a valid set of paths or explicitly set to empty (`PATH=`).
 
 #### Labels
 

--- a/distribution.md
+++ b/distribution.md
@@ -11,7 +11,11 @@ This document specifies the artifact format and the delivery mechanism for the b
   - [Distribution API Version](#distribution-api-version)
   - [Artifact Format](#artifact-format)
     - [Buildpackage](#buildpackage)
+<<<<<<< HEAD
     - [Lifecycle](#lifecycle)
+=======
+    - [Build Image](#build-image)
+>>>>>>> feat: build-image distribution spec
 
 ## Distribution API Version
 
@@ -155,3 +159,37 @@ Where:
     * contain an array of deprecated APIs:
       * should only contain `0.x` or major versions
       * should only contain APIs that correspond to a spec release
+### Build Image
+
+The following defines how a `build-image` SHOULD be packaged for distribution as an OCI Image. The `build-image` is the component that provides the base image from which the build environment is constructed.
+
+The image configuration refers to the OCI Image configuration as mentioned [here](https://github.com/opencontainers/image-spec/blob/main/config.md#properties).
+
+#### Image Configuration
+
+The Build Image MUST contain the following configurations:
+
+* Image Config's `config.User` field MUST be set to a non-root user with a writable home directory.
+* Image Config's `os` field MUST be set to the underlying operating system used by the build image.
+* Image Config's `architecture` field MUST be set to the underlying operating system architecture used by the build image.
+
+The Build Image SHOULD contain the following configurations:
+
+* Image Config's `variant` field SHOULD be set to the underlying architecture variant.
+
+#### Environment Variables
+
+The Build Image MUST contain the following Environment Variables:
+
+* Image Config's `config.Env` field MUST have the environment variable `CNB_USER_ID` set to the user UID/SID of the user specified in the `User` field.
+* Image Config's `config.Env` field MUST have the environment variable `CNB_GROUP_ID` set to the primary group GID/SID of the user specified in the `User` field.
+* Image Config's `config.Env` field MUST have the environment variable `PATH` set to a valid set of paths or explicitly set to empty. (`PATH=`).
+
+#### Labels
+
+The Build Image SHOULD contain the following Labels on the image configuration:
+
+| Label                   | Description
+|-------                  |------------
+| `io.buildpacks.distribution.name` | A string denoting the operating system distribution
+| `io.buildpacks.distribution.version` | A string denoting the operating system version

--- a/distribution.md
+++ b/distribution.md
@@ -169,20 +169,17 @@ The image configuration refers to the OCI Image configuration as mentioned [here
 
 The Build Image MUST contain the following configurations:
 
-* Image Config's `config.User` field MUST be set to a non-root user with a writable home directory.
+* Image Config's `config.User` field MUST be set to the user [†](README.md#operating-system-conventions)UID/[‡](README.md#operating-system-conventions)SID with a writable home directory.
 * Image Config's `os` field MUST be set to the underlying operating system used by the build image.
 * Image Config's `architecture` field MUST be set to the underlying operating system architecture used by the build image.
-
-The Build Image SHOULD contain the following configurations:
-
-* Image Config's `variant` field SHOULD be set to the underlying architecture variant.
+* Image Config's `variant` field MUST be set to the underlying architecture variant.
 
 #### Environment Variables
 
 The Build Image MUST contain the following Environment Variables:
 
 * Image Config's `config.Env` field MUST have the environment variable `CNB_USER_ID` set to the user [†](README.md#operating-system-conventions)UID/[‡](README.md#operating-system-conventions)SID of the user specified in the `User` field.
-* Image Config's `config.Env` field MUST have the environment variable `CNB_GROUP_ID` set to the primary group GID/SID of the user specified in the `User` field.
+* Image Config's `config.Env` field MUST have the environment variable `CNB_GROUP_ID` set to the primary group [†](README.md#operating-system-conventions)GID/[‡](README.md#operating-system-conventions)SID of the user specified in the `User` field.
 * Image Config's `config.Env` field MUST have the environment variable `PATH` set to a valid set of paths or explicitly set to empty (`PATH=`).
 
 #### Labels


### PR DESCRIPTION
This PR consists the artifact format and the delivery mechanism for Buildpacks' Build Image.

Major changes/addition involve:

* Removing "Stack" related fields from the image manifest and instead using Image Config's `os`, `architecture` field.


Signed-off-by: Jimil Desai <jimildesai42@gmail.com>