### PR TITLE
Make the platform api more agnostic about the buildpack api WRT bom support

### DIFF
--- a/platform.md
+++ b/platform.md
@@ -1020,7 +1020,7 @@ Where:
 - **If** the app image was exported to a docker daemon
   - `imageID` MUST contain the imageID
 - **If** the app image was the result of a build operation
-  - `build.bom` MUST contain any legacy build Bill of Materials entries returned by buildpacks (where [supported]((buildpack.md)))
+  - `build.bom` MUST contain any legacy build Bill of Materials entries returned by buildpacks (where [supported](buildpack.md))
 
 #### `stack.toml` (TOML)
 

--- a/platform.md
+++ b/platform.md
@@ -1087,7 +1087,7 @@ Where:
 Where:
 - `processes` MUST contain all buildpack contributed processes
 - `buildpacks` MUST contain the detected group
-- `bom` MUST contain the legacy Bill of Materials contributed by buildpacks (where [supported]((buildpack.md)))
+- `bom` MUST contain the legacy Bill of Materials contributed by buildpacks (where [supported](buildpack.md))
 - `launcher.version` SHOULD contain the version of the `launcher` binary included in the app
 - `launcher.source.git.repository` SHOULD contain the git repository containing the `launcher` source code
 - `launcher.source.git.commit` SHOULD contain the git commit from which the given `launcher` was built

--- a/platform.md
+++ b/platform.md
@@ -937,7 +937,7 @@ Where:
 - `id`, `version`, and `api` MUST be present for each buildpack
 - `processes` contains the complete set of processes contributed by all buildpacks
 - `slices` contains the complete set of slices defined by all buildpacks
-- `bom` contains the legacy Bill of Materials contributed by buildpacks (where [supported]((buildpack.md)))
+- `bom` contains the legacy Bill of Materials contributed by buildpacks (where [supported](buildpack.md))
 
 #### `order.toml` (TOML)
 

--- a/platform.md
+++ b/platform.md
@@ -937,7 +937,7 @@ Where:
 - `id`, `version`, and `api` MUST be present for each buildpack
 - `processes` contains the complete set of processes contributed by all buildpacks
 - `slices` contains the complete set of slices defined by all buildpacks
-- `bom` contains the Bill of Materials contributed by buildpacks implementing Buildpack API < 0.7
+- `bom` contains the legacy Bill of Materials contributed by buildpacks (where [supported]((buildpack.md)))
 
 #### `order.toml` (TOML)
 
@@ -1020,7 +1020,7 @@ Where:
 - **If** the app image was exported to a docker daemon
   - `imageID` MUST contain the imageID
 - **If** the app image was the result of a build operation
-  - `build.bom` MUST contain any build Bill of Materials entries returned by buildpacks implementing Buildpack API < 0.7
+  - `build.bom` MUST contain any legacy build Bill of Materials entries returned by buildpacks (where [supported]((buildpack.md)))
 
 #### `stack.toml` (TOML)
 
@@ -1087,7 +1087,7 @@ Where:
 Where:
 - `processes` MUST contain all buildpack contributed processes
 - `buildpacks` MUST contain the detected group
-- `bom` MUST contain the Bill of Materials contributed by buildpacks implementing Buildpack API < 0.7
+- `bom` MUST contain the legacy Bill of Materials contributed by buildpacks (where [supported]((buildpack.md)))
 - `launcher.version` SHOULD contain the version of the `launcher` binary included in the app
 - `launcher.source.git.repository` SHOULD contain the git repository containing the `launcher` source code
 - `launcher.source.git.commit` SHOULD contain the git commit from which the given `launcher` was built


### PR DESCRIPTION
Per discussion in 1/13 working group. If the platform api had originally been worded this way, we could've released a lifecycle patch to allow both bom behaviors in the same buildpack api without any spec changes.

cc @matthewmcnew @samj1912 @ekcasey 