### PR TITLE
Clarify the behavior when a feature isn't specified as deprecated

### DIFF
--- a/buildpack.md
+++ b/buildpack.md
@@ -1123,6 +1123,8 @@ Each `key`:
 
 ## Deprecations
 This section describes all the features that are deprecated.
+Unless noted below, the lifecycle SHOULD fail if a buildpack declaring a newer Buildpack API tries to use features from an older Buildpack API.
+The lifecycle SHOULD warn and ignore if a buildpack declaring an older Buildpack API tries to use features from a newer Buildpack API.
 
 ### `0.3`
 


### PR DESCRIPTION
This is the rule the lifecycle has been following - we should make it explicit.

But since this wasn't made explicit in Buildpack API <= 0.7, we could theoretically allow both old and new behaviors in those api versions without updating the "deprecated" list. If we want to continue to allow old and new behaviors in 0.8, we should update the list.