### PR TITLE
Add deprecation path for buildpacks using the legacy BOM format.

### DIFF
--- a/buildpack.md
+++ b/buildpack.md
@@ -1124,6 +1124,52 @@ Each `key`:
 ## Deprecations
 This section describes all the features that are deprecated.
 
+### `0.7`
+
+#### launch.toml (TOML) `bom` Array
+
+The `bom` array is deprecated.
+
+```toml
+[[bom]]
+name = "<dependency name>"
+
+[bom.metadata]
+# arbitrary metadata describing the dependency
+```
+
+If the `bom` array is used, the buildpack:
+- SHOULD add a bill-of-materials entry to the `bom` array describing each dependency contributed to the app image, where:
+  - `name` is REQUIRED.
+  - `metadata` MAY contain additional data describing the dependency.
+
+The buildpack MAY add `bom` describing the contents of the app dir, even if they were not contributed by the buildpack.
+
+When the build is complete, a legacy Bill of Materials (BOM) describing the app image MAY be generated for auditing purposes.
+
+If generated, this legacy BOM MUST contain all `bom` entries in each `launch.toml` at the end of each `/bin/build` execution, in adherence with the process and data format outlined in the [Platform Interface Specification](platform.md) for legacy BOM formats.
+
+#### build.toml (TOML) `bom` Array
+
+The `bom` array is deprecated.
+
+```toml
+[[bom]]
+name = "<dependency name>"
+
+[bom.metadata]
+# arbitrary metadata describing the dependency
+```
+
+If the `bom` array is used, the buildpack:
+- SHOULD add a bill-of-materials entry to the `bom` array describing each dependency contributed to the build environment, where:
+  - `name` is REQUIRED.
+  - `metadata` MAY contain additional data describing the dependency.
+
+When the build is complete, a legacy build BOM describing the build container MAY be generated for auditing purposes.
+
+If generated, this legacy build BOM MUST contain all `bom` entries in each `build.toml` at the end of each `/bin/build` execution, in adherence with the process and data format outlined in the [Platform Interface Specification](platform.md) for legacy BOM formats.
+
 ### `0.3`
 
 #### Build Plan (TOML) `requires.version` Key


### PR DESCRIPTION
When we released the new SBOM, we created the following problem:

* Old platforms (that expect to find the BOM in a label) can't upgrade their buildpacks to the 0.7 api - or if they do, the BOM will just disappear. This means that in order to use newer buildpacks, platform operators who were using the old BOM must also upgrade their platform to 0.8+. This is a more difficult migration path than we would like.

This PR proposes that buildpacks should be able to output both the old and the new BOM formats. Then older platforms will still have a BOM in the label, while newer platforms will have both.