### PR TITLE
Deprecate positional args to `build` and `detect` and add env vars

### DIFF
--- a/buildpack.md
+++ b/buildpack.md
@@ -1128,9 +1128,30 @@ Each `key`:
 ## Deprecations
 This section describes all the features that are deprecated.
 
-### `0.7`
 
-#### launch.toml (TOML) `bom` Array
+### Positional Arguments to `detect` and `build` Executables
+
+_Deprecated in Buildpack API 0.8._
+
+The positional arguments to the `detect` and `build` executables are deprecated.
+The lifecycle provides these values as environment variables.
+
+To upgrade, buildpack authors SHOULD use the following environment variables:
+
+For `detect`:
+
+- `CNB_PLATFORM_DIR` replaces the first positional argument.
+- `CNB_BUILD_PLAN_PATH` replaces the second positional argument.
+
+For `build`:
+
+* `CNB_LAYERS_DIR` replaces the first positional argument.
+* `CNB_PLATFORM_DIR` replaces the second positional argument.
+* `CNB_BP_PLAN_PATH` replaces the third positional argument.
+
+### launch.toml (TOML) `bom` Array
+
+_Deprecated in Buildpack API 0.7._
 
 The `bom` array is deprecated.
 
@@ -1153,7 +1174,9 @@ When the build is complete, a legacy Bill of Materials (BOM) describing the app 
 
 If generated, this legacy BOM MUST contain all `bom` entries in each `launch.toml` at the end of each `/bin/build` execution, in adherence with the process and data format outlined in the [Platform Interface Specification](platform.md) for legacy BOM formats.
 
-#### build.toml (TOML) `bom` Array
+### build.toml (TOML) `bom` Array
+
+_Deprecated in Buildpack API 0.7._
 
 The `bom` array is deprecated.
 
@@ -1174,9 +1197,10 @@ When the build is complete, a legacy build BOM describing the build container MA
 
 If generated, this legacy build BOM MUST contain all `bom` entries in each `build.toml` at the end of each `/bin/build` execution, in adherence with the process and data format outlined in the [Platform Interface Specification](platform.md) for legacy BOM formats.
 
-### `0.3`
 
-#### Build Plan (TOML) `requires.version` Key
+### Build Plan (TOML) `requires.version` Key
+
+_Deprecated in Buildpack API 0.3._
 
 The `requires.version` and `or.requires.version` keys are deprecated.
 
@@ -1217,23 +1241,3 @@ name = "<dependency name>"
 [entries.metadata]
 version = "<dependency version>"
 ```
-
-### `0.8`
-
-#### Positional Arguments to `detect` and `build` Executables
-
-The positional arguments to the `detect` and `build` executables are deprecated.
-The lifecycle provides these values as environment variables.
-
-To upgrade, buildpack authors SHOULD use the following environment variables:
-
-For `detect`:
-
-- `CNB_PLATFORM_DIR` replaces the first positional argument.
-- `CNB_BUILD_PLAN_PATH` replaces the second positional argument.
-
-For `build`:
-
-* `CNB_LAYERS_DIR` replaces the first positional argument.
-* `CNB_PLATFORM_DIR` replaces the second positional argument.
-* `CNB_BP_PLAN_PATH` replaces the third positional argument.

--- a/buildpack.md
+++ b/buildpack.md
@@ -121,13 +121,13 @@ Executable: `/bin/detect <platform[AR]> <plan[E]>`, Working Dir: `<app[AR]>`
 
 Note: the positional arguments to `/bin/detect` are deprecated, and buildpack authors SHOULD use the corresponding environment variables.
 
-| Input                    | Description                                   |
-|--------------------------|-----------------------------------------------|
-| `$0`                     | Absolute path of `/bin/detect` executable     |
-| `$CNB_BUILD_PLAN_PATH`   | Absolute path of the build plan               |
-| `$CNB_PLATFORM_DIR`      | Absolute path of the platform directory       |
-| `$CNB_PLATFORM_DIR/env/` | User-provided environment variables for build |
-| `$CNB_PLATFORM_DIR/#`    | Platform-specific extensions                  |
+| Input                    | Attributes | Description                                   |
+|--------------------------|------------|-----------------------------------------------|
+| `$0`                     |            | Absolute path of `/bin/detect` executable     |
+| `$CNB_BUILD_PLAN_PATH`   | E          | Absolute path of the build plan               |
+| `$CNB_PLATFORM_DIR`      | AR         | Absolute path of the platform directory       |
+| `$CNB_PLATFORM_DIR/env/` |            | User-provided environment variables for build |
+| `$CNB_PLATFORM_DIR/#`    |            | Platform-specific extensions                  |
 
 | Output                 | Description                                 |
 |------------------------|---------------------------------------------|
@@ -143,14 +143,14 @@ Executable: `/bin/build <layers[EIC]> <platform[AR]> <plan[ER]>`, Working Dir: `
 
 Note: the positional arguments to `/bin/detect` are deprecated, and buildpack authors SHOULD use the corresponding environment variables.
 
-| Input                    | Description                                                                   |
-|--------------------------|-------------------------------------------------------------------------------|
-| `$0`                     | Absolute path of `/bin/build` executable                                      |
-| `$CNB_LAYERS_DIR`        | Absolute path of the buildpack layers directory                               |
-| `$CNB_BP_PLAN_PATH`      | Relevant [Buildpack Plan entries](#buildpack-plan-toml) from detection (TOML) |
-| `$CNB_PLATFORM_DIR`      | Absolute path of the platform directory                                       |
-| `$CNB_PLATFORM_DIR/env/` | User-provided environment variables for build                                 |
-| `$CNB_PLATFORM_DIR/#`    | Platform-specific extensions                                                  |
+| Input                    | Attributes | Description                                                                   |
+|--------------------------|------------|-------------------------------------------------------------------------------|
+| `$0`                     |            | Absolute path of `/bin/build` executable                                      |
+| `$CNB_LAYERS_DIR`        | EIC        | Absolute path of the buildpack layers directory                               |
+| `$CNB_BP_PLAN_PATH`      | ER         | Relevant [Buildpack Plan entries](#buildpack-plan-toml) from detection (TOML) |
+| `$CNB_PLATFORM_DIR`      | AR         | Absolute path of the platform directory                                       |
+| `$CNB_PLATFORM_DIR/env/` |            | User-provided environment variables for build                                 |
+| `$CNB_PLATFORM_DIR/#`    |            | Platform-specific extensions                                                  |
 
 | Output                                          | Description                                                                                                      |
 |-------------------------------------------------|------------------------------------------------------------------------------------------------------------------|

--- a/buildpack.md
+++ b/buildpack.md
@@ -117,9 +117,7 @@ The lifecycle MAY return an error to the platform if two or more buildpacks with
 
 ### Detection
 
-Executable: `/bin/detect <platform[AR]> <plan[E]>`, Working Dir: `<app[AR]>`
-
-Note: the positional arguments to `/bin/detect` are deprecated, and buildpack authors SHOULD use the corresponding environment variables.
+Executable: `/bin/detect`, Working Dir: `<app[AR]>`
 
 | Input                    | Attributes | Description                                   |
 |--------------------------|------------|-----------------------------------------------|
@@ -139,9 +137,7 @@ Note: the positional arguments to `/bin/detect` are deprecated, and buildpack au
 
 ###  Build
 
-Executable: `/bin/build <layers[EIC]> <platform[AR]> <plan[ER]>`, Working Dir: `<app[AI]>`
-
-Note: the positional arguments to `/bin/detect` are deprecated, and buildpack authors SHOULD use the corresponding environment variables.
+Executable: `/bin/build`, Working Dir: `<app[AI]>`
 
 | Input                    | Attributes | Description                                                                   |
 |--------------------------|------------|-------------------------------------------------------------------------------|

--- a/buildpack.md
+++ b/buildpack.md
@@ -84,7 +84,7 @@ The `ENTRYPOINT` of the OCI image contains logic implemented by the lifecycle th
       - [Build Plan (TOML) `requires.version` Key](#build-plan-toml-requiresversion-key)
 
 ## Buildpack API Version
-This document specifies Buildpack API version `0.7`
+This document specifies Buildpack API version `0.8`
 
 Buildpack API versions:
  - MUST be in form `<major>.<minor>` or `<major>`, where `<major>` is equivalent to `<major>.0`
@@ -119,56 +119,64 @@ The lifecycle MAY return an error to the platform if two or more buildpacks with
 
 Executable: `/bin/detect <platform[AR]> <plan[E]>`, Working Dir: `<app[AR]>`
 
+Note: the positional arguments to `/bin/detect` are deprecated, and buildpack authors SHOULD use the corresponding environment variables.
+
 | Input             | Description
 |-------------------|----------------------------------------------
 | `$0`              | Absolute path of `/bin/detect` executable
-| `<platform>/env/` | User-provided environment variables for build
-| `<platform>/#`    | Platform-specific extensions
+| `$CNB_BUILD_PLAN_PATH` | Absolute path of the build plan
+| `$CNB_PLATFORM_DIR`    | Absolute path of the platform directory
+| `$CNB_PLATFORM_DIR/env/` | User-provided environment variables for build
+| `$CNB_PLATFORM_DIR/#`    | Platform-specific extensions
 
 | Output             | Description
 |--------------------|----------------------------------------------
 | [exit status]      | Pass (0), fail (100), or error (1-99, 101+)
 | Standard output    | Logs (info)
 | Standard error     | Logs (warnings, errors)
-| `<plan>`           | Contributions to the the Build Plan (TOML)
+| `$CNB_BUILD_PLAN_PATH` | Contributions to the the Build Plan (TOML)
 
 
 ###  Build
 
 Executable: `/bin/build <layers[EIC]> <platform[AR]> <plan[ER]>`, Working Dir: `<app[AI]>`
 
+Note: the positional arguments to `/bin/detect` are deprecated, and buildpack authors SHOULD use the corresponding environment variables.
+
 | Input             | Description
 |-------------------|----------------------------------------------
 | `$0`              | Absolute path of `/bin/build` executable
-| `<plan>`          | Relevant [Buildpack Plan entries](#buildpack-plan-toml) from detection (TOML)
-| `<platform>/env/` | User-provided environment variables for build
-| `<platform>/#`    | Platform-specific extensions
+| `$CNB_LAYERS_DIR` | Absolute path of the buildpack layers directory
+| `$CNB_BP_PLAN_PATH`  | Relevant [Buildpack Plan entries](#buildpack-plan-toml) from detection (TOML)
+| `$CNB_PLATFORM_DIR`  | Absolute path of the platform directory
+| `$CNB_PLATFORM_DIR/env/` | User-provided environment variables for build
+| `$CNB_PLATFORM_DIR/#`    | Platform-specific extensions
 
 | Output                                   | Description
 |------------------------------------------|--------------------------------------
 | [exit status]                            | Success (0) or failure (1+)
 | Standard output                          | Logs (info)
 | Standard error                           | Logs (warnings, errors)
-| `<layers>/launch.toml`                   | App metadata (see [launch.toml](#launchtoml-toml))
-| `<layers>/launch.sbom.<ext>`             | Launch Software Bill of Materials (see [Software-Bill-of-Materials](#software-bill-of-materials))
-| `<layers>/build.toml`                    | Build metadata (see [build.toml](#buildtoml-toml))
-| `<layers>/build.sbom.<ext>`              | Build Software Bill of Materials (see [Software-Bill-of-Materials](#software-bill-of-materials))
-| `<layers>/store.toml`                    | Persistent metadata (see [store.toml](#storetoml-toml))
-| `<layers>/<layer>.toml`                  | Layer metadata (see [Layer Content Metadata](#layer-content-metadata-toml))
-| `<layers>/<layer>.sbom.<ext>`            | Layer Software Bill of Materials (see [Software-Bill-of-Materials](#software-bill-of-materials))
-| `<layers>/<layer>/bin/`                  | Binaries for launch and/or subsequent buildpacks
-| `<layers>/<layer>/lib/`                  | Shared libraries for launch and/or subsequent buildpacks
-| `<layers>/<layer>/profile.d/`            | Scripts sourced by Bash before launch
-| `<layers>/<layer>/profile.d/<process>/`  | Scripts sourced by Bash before launch for a particular process type
-| `<layers>/<layer>/exec.d/`               | Executables that provide env vars via the [Exec.d Interface](#execd) before launch
-| `<layers>/<layer>/exec.d/<process>/`     | Executables that provide env vars for a particular process type via the [Exec.d Interface](#execd) before launch
-| `<layers>/<layer>/include/`              | C/C++ headers for subsequent buildpacks
-| `<layers>/<layer>/pkgconfig/`            | Search path for pkg-config for subsequent buildpacks
-| `<layers>/<layer>/env/`                  | Env vars for launch and/or subsequent buildpacks
-| `<layers>/<layer>/env.launch/`           | Env vars for launch (after `env`, before `profile.d`)
-| `<layers>/<layer>/env.launch/<process>/` | Env vars for launch (after `env`, before `profile.d`) for the launched process
-| `<layers>/<layer>/env.build/`            | Env vars for subsequent buildpacks (after `env`)
-| `<layers>/<layer>/*`                     | Other content for launch and/or subsequent buildpacks
+| `$CNB_LAYERS_DIR/launch.toml`                   | App metadata (see [launch.toml](#launchtoml-toml))
+| `$CNB_LAYERS_DIR/launch.sbom.<ext>`             | Launch Software Bill of Materials (see [Software-Bill-of-Materials](#software-bill-of-materials))
+| `$CNB_LAYERS_DIR/build.toml`                    | Build metadata (see [build.toml](#buildtoml-toml))
+| `$CNB_LAYERS_DIR/build.sbom.<ext>`              | Build Software Bill of Materials (see [Software-Bill-of-Materials](#software-bill-of-materials))
+| `$CNB_LAYERS_DIR/store.toml`                    | Persistent metadata (see [store.toml](#storetoml-toml))
+| `$CNB_LAYERS_DIR/<layer>.toml`                  | Layer metadata (see [Layer Content Metadata](#layer-content-metadata-toml))
+| `$CNB_LAYERS_DIR/<layer>.sbom.<ext>`            | Layer Software Bill of Materials (see [Software-Bill-of-Materials](#software-bill-of-materials))
+| `$CNB_LAYERS_DIR/<layer>/bin/`                  | Binaries for launch and/or subsequent buildpacks
+| `$CNB_LAYERS_DIR/<layer>/lib/`                  | Shared libraries for launch and/or subsequent buildpacks
+| `$CNB_LAYERS_DIR/<layer>/profile.d/`            | Scripts sourced by Bash before launch
+| `$CNB_LAYERS_DIR/<layer>/profile.d/<process>/`  | Scripts sourced by Bash before launch for a particular process type
+| `$CNB_LAYERS_DIR/<layer>/exec.d/`               | Executables that provide env vars via the [Exec.d Interface](#execd) before launch
+| `$CNB_LAYERS_DIR/<layer>/exec.d/<process>/`     | Executables that provide env vars for a particular process type via the [Exec.d Interface](#execd) before launch
+| `$CNB_LAYERS_DIR/<layer>/include/`              | C/C++ headers for subsequent buildpacks
+| `$CNB_LAYERS_DIR/<layer>/pkgconfig/`            | Search path for pkg-config for subsequent buildpacks
+| `$CNB_LAYERS_DIR/<layer>/env/`                  | Env vars for launch and/or subsequent buildpacks
+| `$CNB_LAYERS_DIR/<layer>/env.launch/`           | Env vars for launch (after `env`, before `profile.d`)
+| `$CNB_LAYERS_DIR/<layer>/env.launch/<process>/` | Env vars for launch (after `env`, before `profile.d`) for the launched process
+| `$CNB_LAYERS_DIR/<layer>/env.build/`            | Env vars for subsequent buildpacks (after `env`)
+| `$CNB_LAYERS_DIR/<layer>/*`                     | Other content for launch and/or subsequent buildpacks
 
 ### Exec.d
 
@@ -1213,3 +1221,23 @@ name = "<dependency name>"
 [entries.metadata]
 version = "<dependency version>"
 ```
+
+### `0.8`
+
+#### Positional Arguments to `detect` and `build` Executables
+
+The positional arguments to the `detect` and `build` executables are deprecated.
+The lifecycle provides these values as environment variables.
+
+To upgrade, buildpack authors SHOULD use the following environment variables:
+
+For `detect`:
+
+- `CNB_PLATFORM_DIR` replaces the first positional argument.
+- `CNB_BUILD_PLAN_PATH` replaces the second positional argument.
+
+For `build`:
+
+* `CNB_LAYERS_DIR` replaces the first positional argument.
+* `CNB_PLATFORM_DIR` replaces the second positional argument.
+* `CNB_BP_PLAN_PATH` replaces the third positional argument.

--- a/buildpack.md
+++ b/buildpack.md
@@ -121,20 +121,20 @@ Executable: `/bin/detect <platform[AR]> <plan[E]>`, Working Dir: `<app[AR]>`
 
 Note: the positional arguments to `/bin/detect` are deprecated, and buildpack authors SHOULD use the corresponding environment variables.
 
-| Input             | Description
-|-------------------|----------------------------------------------
-| `$0`              | Absolute path of `/bin/detect` executable
-| `$CNB_BUILD_PLAN_PATH` | Absolute path of the build plan
-| `$CNB_PLATFORM_DIR`    | Absolute path of the platform directory
-| `$CNB_PLATFORM_DIR/env/` | User-provided environment variables for build
-| `$CNB_PLATFORM_DIR/#`    | Platform-specific extensions
+| Input                    | Description                                   |
+|--------------------------|-----------------------------------------------|
+| `$0`                     | Absolute path of `/bin/detect` executable     |
+| `$CNB_BUILD_PLAN_PATH`   | Absolute path of the build plan               |
+| `$CNB_PLATFORM_DIR`      | Absolute path of the platform directory       |
+| `$CNB_PLATFORM_DIR/env/` | User-provided environment variables for build |
+| `$CNB_PLATFORM_DIR/#`    | Platform-specific extensions                  |
 
-| Output             | Description
-|--------------------|----------------------------------------------
-| [exit status]      | Pass (0), fail (100), or error (1-99, 101+)
-| Standard output    | Logs (info)
-| Standard error     | Logs (warnings, errors)
-| `$CNB_BUILD_PLAN_PATH` | Contributions to the the Build Plan (TOML)
+| Output                 | Description                                 |
+|------------------------|---------------------------------------------|
+| [exit status]          | Pass (0), fail (100), or error (1-99, 101+) |
+| Standard output        | Logs (info)                                 |
+| Standard error         | Logs (warnings, errors)                     |
+| `$CNB_BUILD_PLAN_PATH` | Contributions to the the Build Plan (TOML)  |
 
 
 ###  Build
@@ -143,40 +143,40 @@ Executable: `/bin/build <layers[EIC]> <platform[AR]> <plan[ER]>`, Working Dir: `
 
 Note: the positional arguments to `/bin/detect` are deprecated, and buildpack authors SHOULD use the corresponding environment variables.
 
-| Input             | Description
-|-------------------|----------------------------------------------
-| `$0`              | Absolute path of `/bin/build` executable
-| `$CNB_LAYERS_DIR` | Absolute path of the buildpack layers directory
-| `$CNB_BP_PLAN_PATH`  | Relevant [Buildpack Plan entries](#buildpack-plan-toml) from detection (TOML)
-| `$CNB_PLATFORM_DIR`  | Absolute path of the platform directory
-| `$CNB_PLATFORM_DIR/env/` | User-provided environment variables for build
-| `$CNB_PLATFORM_DIR/#`    | Platform-specific extensions
+| Input                    | Description                                                                   |
+|--------------------------|-------------------------------------------------------------------------------|
+| `$0`                     | Absolute path of `/bin/build` executable                                      |
+| `$CNB_LAYERS_DIR`        | Absolute path of the buildpack layers directory                               |
+| `$CNB_BP_PLAN_PATH`      | Relevant [Buildpack Plan entries](#buildpack-plan-toml) from detection (TOML) |
+| `$CNB_PLATFORM_DIR`      | Absolute path of the platform directory                                       |
+| `$CNB_PLATFORM_DIR/env/` | User-provided environment variables for build                                 |
+| `$CNB_PLATFORM_DIR/#`    | Platform-specific extensions                                                  |
 
-| Output                                   | Description
-|------------------------------------------|--------------------------------------
-| [exit status]                            | Success (0) or failure (1+)
-| Standard output                          | Logs (info)
-| Standard error                           | Logs (warnings, errors)
-| `$CNB_LAYERS_DIR/launch.toml`                   | App metadata (see [launch.toml](#launchtoml-toml))
-| `$CNB_LAYERS_DIR/launch.sbom.<ext>`             | Launch Software Bill of Materials (see [Software-Bill-of-Materials](#software-bill-of-materials))
-| `$CNB_LAYERS_DIR/build.toml`                    | Build metadata (see [build.toml](#buildtoml-toml))
-| `$CNB_LAYERS_DIR/build.sbom.<ext>`              | Build Software Bill of Materials (see [Software-Bill-of-Materials](#software-bill-of-materials))
-| `$CNB_LAYERS_DIR/store.toml`                    | Persistent metadata (see [store.toml](#storetoml-toml))
-| `$CNB_LAYERS_DIR/<layer>.toml`                  | Layer metadata (see [Layer Content Metadata](#layer-content-metadata-toml))
-| `$CNB_LAYERS_DIR/<layer>.sbom.<ext>`            | Layer Software Bill of Materials (see [Software-Bill-of-Materials](#software-bill-of-materials))
-| `$CNB_LAYERS_DIR/<layer>/bin/`                  | Binaries for launch and/or subsequent buildpacks
-| `$CNB_LAYERS_DIR/<layer>/lib/`                  | Shared libraries for launch and/or subsequent buildpacks
-| `$CNB_LAYERS_DIR/<layer>/profile.d/`            | Scripts sourced by Bash before launch
-| `$CNB_LAYERS_DIR/<layer>/profile.d/<process>/`  | Scripts sourced by Bash before launch for a particular process type
-| `$CNB_LAYERS_DIR/<layer>/exec.d/`               | Executables that provide env vars via the [Exec.d Interface](#execd) before launch
-| `$CNB_LAYERS_DIR/<layer>/exec.d/<process>/`     | Executables that provide env vars for a particular process type via the [Exec.d Interface](#execd) before launch
-| `$CNB_LAYERS_DIR/<layer>/include/`              | C/C++ headers for subsequent buildpacks
-| `$CNB_LAYERS_DIR/<layer>/pkgconfig/`            | Search path for pkg-config for subsequent buildpacks
-| `$CNB_LAYERS_DIR/<layer>/env/`                  | Env vars for launch and/or subsequent buildpacks
-| `$CNB_LAYERS_DIR/<layer>/env.launch/`           | Env vars for launch (after `env`, before `profile.d`)
-| `$CNB_LAYERS_DIR/<layer>/env.launch/<process>/` | Env vars for launch (after `env`, before `profile.d`) for the launched process
-| `$CNB_LAYERS_DIR/<layer>/env.build/`            | Env vars for subsequent buildpacks (after `env`)
-| `$CNB_LAYERS_DIR/<layer>/*`                     | Other content for launch and/or subsequent buildpacks
+| Output                                          | Description                                                                                                      |
+|-------------------------------------------------|------------------------------------------------------------------------------------------------------------------|
+| [exit status]                                   | Success (0) or failure (1+)                                                                                      |
+| Standard output                                 | Logs (info)                                                                                                      |
+| Standard error                                  | Logs (warnings, errors)                                                                                          |
+| `$CNB_LAYERS_DIR/launch.toml`                   | App metadata (see [launch.toml](#launchtoml-toml))                                                               |
+| `$CNB_LAYERS_DIR/launch.sbom.<ext>`             | Launch Software Bill of Materials (see [Software-Bill-of-Materials](#software-bill-of-materials))                |
+| `$CNB_LAYERS_DIR/build.toml`                    | Build metadata (see [build.toml](#buildtoml-toml))                                                               |
+| `$CNB_LAYERS_DIR/build.sbom.<ext>`              | Build Software Bill of Materials (see [Software-Bill-of-Materials](#software-bill-of-materials))                 |
+| `$CNB_LAYERS_DIR/store.toml`                    | Persistent metadata (see [store.toml](#storetoml-toml))                                                          |
+| `$CNB_LAYERS_DIR/<layer>.toml`                  | Layer metadata (see [Layer Content Metadata](#layer-content-metadata-toml))                                      |
+| `$CNB_LAYERS_DIR/<layer>.sbom.<ext>`            | Layer Software Bill of Materials (see [Software-Bill-of-Materials](#software-bill-of-materials))                 |
+| `$CNB_LAYERS_DIR/<layer>/bin/`                  | Binaries for launch and/or subsequent buildpacks                                                                 |
+| `$CNB_LAYERS_DIR/<layer>/lib/`                  | Shared libraries for launch and/or subsequent buildpacks                                                         |
+| `$CNB_LAYERS_DIR/<layer>/profile.d/`            | Scripts sourced by Bash before launch                                                                            |
+| `$CNB_LAYERS_DIR/<layer>/profile.d/<process>/`  | Scripts sourced by Bash before launch for a particular process type                                              |
+| `$CNB_LAYERS_DIR/<layer>/exec.d/`               | Executables that provide env vars via the [Exec.d Interface](#execd) before launch                               |
+| `$CNB_LAYERS_DIR/<layer>/exec.d/<process>/`     | Executables that provide env vars for a particular process type via the [Exec.d Interface](#execd) before launch |
+| `$CNB_LAYERS_DIR/<layer>/include/`              | C/C++ headers for subsequent buildpacks                                                                          |
+| `$CNB_LAYERS_DIR/<layer>/pkgconfig/`            | Search path for pkg-config for subsequent buildpacks                                                             |
+| `$CNB_LAYERS_DIR/<layer>/env/`                  | Env vars for launch and/or subsequent buildpacks                                                                 |
+| `$CNB_LAYERS_DIR/<layer>/env.launch/`           | Env vars for launch (after `env`, before `profile.d`)                                                            |
+| `$CNB_LAYERS_DIR/<layer>/env.launch/<process>/` | Env vars for launch (after `env`, before `profile.d`) for the launched process                                   |
+| `$CNB_LAYERS_DIR/<layer>/env.build/`            | Env vars for subsequent buildpacks (after `env`)                                                                 |
+| `$CNB_LAYERS_DIR/<layer>/*`                     | Other content for launch and/or subsequent buildpacks                                                            |
 
 ### Exec.d
 


### PR DESCRIPTION
Per RFC 100: https://github.com/buildpacks/rfcs/blob/main/text/0100-buildpack-input-vars.md

Fixes #294.

Split out markdown table whitespace commit to make the diff more clear - the meat is in commit 3883a60d68fdc2faa443916b478489088939d48a.