### PR TITLE
add platform team lead as a co-codeowner of distribution spec

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,6 @@
 /platform.md @buildpacks/implementation-team-lead @buildpacks/platform-team-lead
 /buildpack.md @buildpacks/bat-team-lead @buildpacks/implementation-team-lead 
-/distribution.md @buildpacks/distribution-team-lead
+/distribution.md @buildpacks/distribution-team-lead @buildpacks/platform-team-lead
 /extensions/buildpack-registry.md @buildpacks/distribution-team-lead
 /extensions/project-descriptor.md @buildpacks/platform-team-lead
 * @buildpacks/team-leads


### PR DESCRIPTION
This came up in the Team Lead WG today. Similar to platform and buildpack specs, there are more than 1 team lead that should sign off on changes here. @jromero made the case that distribution is an extension of platforms.