### PR TITLE
Makes creator spec internally consistent

### DIFF
--- a/platform.md
+++ b/platform.md
@@ -681,7 +681,7 @@ Running `creator` SHALL be equivalent to running `detector`, `analyzer`, `restor
 | `<skip-restore>`  | `CNB_SKIP_RESTORE`  | `false`      | Prevent buildpacks from reusing layers from previous builds, by skipping the restoration of any data to each buildpack's layers directory, with the exception of `store.toml`.
 | `<tag>...`        |                     |              | Additional tag to apply to exported image
 
-- **If** `<skip-restore>` is `true` the `creator` SHALL skip sbom layer restoration and skip the entire Restore phase.
+- **If** `<skip-restore>` is `true` the `creator` SHALL skip the restoration of any data to each buildpack's layers directory, with the exception of `store.toml`.
 - **If** the platform provides one or more `<tag>` inputs they SHALL be treated as additional `<image>` inputs to the `exporter`
 
 ##### Outputs


### PR DESCRIPTION
When `-skip-restore` is passed the creator should still restore store.toml.

There is currently a bug in the lifecycle implementation, because the entire restore phase is skipped, but the restore phase includes store.toml restoration as of platform 0.7.

When platform API is 0.10 or above, the lifecycle will invoke the restore phase but with -skip-layers so that SBOM and layer metadata files are not written to buildpack layer directories.