### PR TITLE
Add buildpack API to io.buildpacks.build.metadata label

### DIFF
--- a/platform.md
+++ b/platform.md
@@ -1231,20 +1231,23 @@ Where:
       ],
       "direct": false,
       "working-dir": "<working-dir>",
+      "buildpackID": "<buildpack ID>"
     }
   ],
   "buildpacks": [
     {
       "id": "<buildpack ID>",
       "version": "<buildpack version>",
-      "homepage": "<buildpack homepage>"
+      "homepage": "<buildpack homepage>",
+      "api": "<buildpack API version>"
     }
   ],
   "extensions": [
     {
       "id": "<extension ID>",
       "version": "<extension version>",
-      "homepage": "<extension homepage>"
+      "homepage": "<extension homepage>",
+      "api": "<buildpack API version>"
     }
   ],
  "launcher": {


### PR DESCRIPTION
This seems to have been an oversight in implementing overridable process args - the launcher has access to buildpack API in `<layers>/config/metadata.toml` but it is not printed in the label, hence platforms do not have all the required information to display processes correctly (or at least, to allow end users to distinguish between overridable and non-overridable args).

For newer platform API (0.10 and above) we need to know the buildpack API to know if the process args are overridable or not (when there is more than one element in the command, the process is definitely from a newer buildpack, but if there is only one element in the command, the args could be overridable or not overridable depending on the buildpack API).

Having this information will allow platforms such as pack to display process information to end users.

The lifecycle is already adding processes[0].buildpackID to the label, this updates the spec to reflect the current implementation.