### PR TITLE
Fix schema version markdown rendering in project-descriptor.md

### DIFF
--- a/extensions/project-descriptor.md
+++ b/extensions/project-descriptor.md
@@ -29,8 +29,8 @@ This document specifies Project Descriptor Schema Version `0.2`.
 
 The Schema Version format follows the form of the [Buildpack API Version](https://github.com/buildpacks/spec/blob/main/buildpack.md#buildpack-api-version):
 
-* MUST be in form <major>.<minor> or <major>, where <major> is equivalent to <major>.0
-* When <major> is greater than 0 increments to <minor> SHALL exclusively indicate additive changes
+* MUST be in form `<major>.<minor>` or `<major>`, where `<major>` is equivalent to `<major>.0`
+* When `<major>` is greater than 0, increments to `<minor>` SHALL exclusively indicate additive changes
 
 ## Special Value Types
 


### PR DESCRIPTION
The `<...>` references must be wrapped with backticks, or they are not rendered at all, making the spec hard to follow.

Example of the current broken rendering:

> MUST be in form . or , where is equivalent to .0

Signed-off-by: Ed Morley <501702+edmorley@users.noreply.github.com>