### PR TITLE
Deprecate version 0.4 of the buildpack API

### DIFF
--- a/buildpack.md
+++ b/buildpack.md
@@ -1,4 +1,8 @@
-# Buildpack Interface Specification
+# Buildpack Interface Specification (DEPRECATED)
+
+## This API version is considered [deprecated](https://github.com/buildpacks/rfcs/blob/main/text/0049-multi-api-lifecycle-descriptor.md) and will become unsupported as of July 1, 2023.
+
+For information about how to migrate, consult the [migration guides](https://buildpacks.io/docs/reference/spec/migration/).
 
 This document specifies the interface between a single lifecycle and one or more buildpacks.
 


### PR DESCRIPTION
According to https://github.com/buildpacks/rfcs/blob/main/text/0110-deprecate-apis.md