### PR TITLE
Deprecate version 0.6 of the platform API

### DIFF
--- a/platform.md
+++ b/platform.md
@@ -1,4 +1,8 @@
-# Platform Interface Specification
+# Platform Interface Specification (DEPRECATED)
+
+## This API version is considered [deprecated](https://github.com/buildpacks/rfcs/blob/main/text/0049-multi-api-lifecycle-descriptor.md) and will become unsupported as of July 1, 2023.
+
+For information about how to migrate, consult the [migration guides](https://buildpacks.io/docs/reference/spec/migration/).
 
 This document specifies the interface between a lifecycle and a platform.
 


### PR DESCRIPTION
According to https://github.com/buildpacks/rfcs/blob/main/text/0110-deprecate-apis.md