### PR TITLE
Define CNB_BUILD_CONFIG_DIR buildpack behavior

### DIFF
--- a/buildpack.md
+++ b/buildpack.md
@@ -164,14 +164,14 @@ The lifecycle MAY return an error to the platform if two or more buildpacks with
 
 Executable: `/bin/detect`, Working Dir: `<app[AR]>`
 
-| Input                    | Attributes | Description                                   |
-|--------------------------|------------|-----------------------------------------------|
-| `$0`                     |            | Absolute path of `/bin/detect` executable     |
-| `$CNB_BUILD_PLAN_PATH`   | E          | Absolute path of the build plan               |
-| `$CNB_BUILDPACK_DIR`     | ER         | Absolute path of the buildpack root directory |
-| `$CNB_PLATFORM_DIR`      | AR         | Absolute path of the platform directory       |
-| `$CNB_PLATFORM_DIR/env/` | AR         | User-provided environment variables for build |
-| `$CNB_PLATFORM_DIR/#`    | AR         | Platform-specific extensions                  |
+| Input                    | Attributes | Description                                       |
+|--------------------------|------------|---------------------------------------------------|
+| `$0`                     |            | Absolute path of `/bin/detect` executable         |
+| `$CNB_BUILD_PLAN_PATH`   | E          | Absolute path of the build plan                   |
+| `$CNB_BUILDPACK_DIR`     | ER         | Absolute path of the buildpack root directory     |
+| `$CNB_PLATFORM_DIR`      | AR         | Absolute path of the platform directory           |
+| `$CNB_PLATFORM_DIR/env/` | AR         | User-provided environment variables for build     |
+| `$CNB_PLATFORM_DIR/#`    | AR         | Platform-specific extensions                      |
 
 | Output                 | Description                                 |
 |------------------------|---------------------------------------------|
@@ -372,10 +372,13 @@ For each image extension ("extension") or component buildpack ("buildpack") in e
 The selected group MUST be filtered to only include extensions and buildpacks with exit status zero.
 The order of the extensions and buildpacks in the group MUST otherwise be preserved.
 
+For each `/bin/detect` executable in each extension or buildpack, the lifecycle:
+
+- MUST configure the environment as described in the [Environment](#environment) section.
+
 The `/bin/detect` executable in each extension or buildpack, when executed:
 
 - MAY read the app directory.
-- MAY read the detect environment as described in the [Environment](#environment) section.
 - MAY emit error, warning, or debug messages to `stderr`.
 - MAY augment the Build Plan by writing TOML to `<plan>`.
 - MUST set an exit status code as described in the [Buildpack Interface](#buildpack-interface) section.
@@ -782,19 +785,19 @@ In either case,
 | `CPATH`                                    | `/include`   | header files     | [x]   |        |
 | `PKG_CONFIG_PATH`                          | `/pkgconfig` | pc files         | [x]   |        |
 
-
 ### Provided by the Platform
 
 The following additional environment variables MUST NOT be overridden by the lifecycle.
 
-| Env Variable    | Description                                    | Detect | Build | Launch
-|-----------------|------------------------------------------------|--------|-------|--------
-| `CNB_STACK_ID`  | Chosen stack ID                                | [x]    | [x]   |
-| `BP_*`          | User-provided variable for buildpack           | [x]    | [x]   |
-| `BPL_*`         | User-provided variable for exec.d              |        |       | [x]
-| `HOME`          | Current user's home directory                  | [x]    | [x]   | [x]
+| Env Variable           | Description                                       | Detect | Build | Launch |
+|------------------------|---------------------------------------------------|--------|-------|--------|
+| `CNB_STACK_ID`         | Chosen stack ID                                   | [x]    | [x]   |        |
+| `BP_*`                 | User-provided variable for buildpack              | [x]    | [x]   |        |
+| `BPL_*`                | User-provided variable for exec.d                 |        |       | [x]    |
+| `HOME`                 | Current user's home directory                     | [x]    | [x]   | [x]    |
 
-During the detection and build phases, the lifecycle MUST provide any user-provided environment variables as files in `<platform>/env/` with file names and contents matching the environment variable names and contents.
+During the detection and build phases, the lifecycle MUST provide as environment variables any user-provided files in `<platform>/env/` with environment variable names and contents matching the file names and contents.
+During the detection and build phases, the lifecycle MUST provide as environment variables any operator-provided files in `<build-config>/env` with environment variable names and contents matching the file names and contents. This applies for all values of `clear-env` or if `clear-env` is undefined in `buildpack.toml`.
 
 When `clear-env` in `buildpack.toml` is set to `true` for a given buildpack, the lifecycle MUST NOT set user-provided environment variables in the environment of `/bin/detect` or `/bin/build`.
 

--- a/platform.md
+++ b/platform.md
@@ -367,7 +367,6 @@ Usage:
   [-app <app>] \
   [-analyzed <analyzed>] \
   [-buildpacks <buildpacks>] \
-  [-build-config <buildConfig>]
   [-extensions <extensions>] \
   [-generated <generated>] \
   [-group <group>] \
@@ -379,21 +378,19 @@ Usage:
 ```
 
 ##### Inputs
-| Input            | Environment Variable   | Default Value                                          | Description                                                                                                                                                  |
-|------------------|------------------------|--------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `<analyzed>`     | `CNB_ANALYZED_PATH`    | `<layers>/analyzed.toml`                               | (**[experimental](#experimental-features)**) Path to output analysis metadata (see [`analyzed.toml`](#analyzedtoml-toml)                                     |
-| `<app>`          | `CNB_APP_DIR`          | `/workspace`                                           | Path to application directory                                                                                                                                |
-| `<buildpacks>`   | `CNB_BUILDPACKS_DIR`   | `/cnb/buildpacks`                                      | Path to buildpacks directory (see [Buildpacks Directory Layout](#buildpacks-directory-layout))                                                               |
-| `<extensions>`   | `CNB_EXTENSIONS_DIR`   | `/cnb/extensions`                                      | (**[experimental](#experimental-features)**) Path to image extensions directory (see [Image Extensions Directory Layout](#image-extensions-directory-layout) |
-| `<generated>`    | `CNB_GENERATED_DIR`    | `<layers>/generated`                                   | (**[experimental](#experimental-features)**) Path to output directory for generated Dockerfiles                                                              |
-| `<group>`        | `CNB_GROUP_PATH`       | `<layers>/group.toml`                                  | Path to output group definition                                                                                                                              |
-| `<layers>`       | `CNB_LAYERS_DIR`       | `/layers`                                              | Path to layers directory                                                                                                                                     |
-| `<log-level>`    | `CNB_LOG_LEVEL`        | `info`                                                 | Log Level                                                                                                                                                    |
-| `<order>`        | `CNB_ORDER_PATH`       | `<layers>/order.toml` if present, or `/cnb/order.toml` | Path resolution for order definition (see [`order.toml`](#ordertoml-toml))                                                                                   |
-| `<plan>`         | `CNB_PLAN_PATH`        | `<layers>/plan.toml`                                   | Path to output resolved build plan                                                                                                                           |
-| `<platform>`     | `CNB_PLATFORM_DIR`     | `/platform`                                            | Path to platform directory                                                                                                                                   |
-| `<build-config>` | `CNB_BUILD_CONFIG_DIR` | `/cnb/build-config`                                    | Path to operator-defined environment variables                                                                                                               |
-
+| Input          | Environment Variable | Default Value                                          | Description                                                                                                                                                  |
+|----------------|----------------------|--------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `<analyzed>`   | `CNB_ANALYZED_PATH`  | `<layers>/analyzed.toml`                               | (**[experimental](#experimental-features)**) Path to output analysis metadata (see [`analyzed.toml`](#analyzedtoml-toml)                                     |
+| `<app>`        | `CNB_APP_DIR`        | `/workspace`                                           | Path to application directory                                                                                                                                |
+| `<buildpacks>` | `CNB_BUILDPACKS_DIR` | `/cnb/buildpacks`                                      | Path to buildpacks directory (see [Buildpacks Directory Layout](#buildpacks-directory-layout))                                                               |
+| `<extensions>` | `CNB_EXTENSIONS_DIR` | `/cnb/extensions`                                      | (**[experimental](#experimental-features)**) Path to image extensions directory (see [Image Extensions Directory Layout](#image-extensions-directory-layout) |
+| `<generated>`  | `CNB_GENERATED_DIR`  | `<layers>/generated`                                   | (**[experimental](#experimental-features)**) Path to output directory for generated Dockerfiles                                                              |
+| `<group>`      | `CNB_GROUP_PATH`     | `<layers>/group.toml`                                  | Path to output group definition                                                                                                                              |
+| `<layers>`     | `CNB_LAYERS_DIR`     | `/layers`                                              | Path to layers directory                                                                                                                                     |
+| `<log-level>`  | `CNB_LOG_LEVEL`      | `info`                                                 | Log Level                                                                                                                                                    |
+| `<order>`      | `CNB_ORDER_PATH`     | `<layers>/order.toml` if present, or `/cnb/order.toml` | Path resolution for order definition (see [`order.toml`](#ordertoml-toml))                                                                                   |
+| `<plan>`       | `CNB_PLAN_PATH`      | `<layers>/plan.toml`                                   | Path to output resolved build plan                                                                                                                           |
+| `<platform>`   | `CNB_PLATFORM_DIR`   | `/platform`                                            | Path to platform directory                                                                                                                                   |
 
 ##### Outputs
 | Output                                                   | Description                                                                                   |
@@ -527,7 +524,6 @@ Usage:
 | `<plan>`             | `CNB_PLAN_PATH`        | `<layers>/plan.toml`     | Path to resolved build plan (see [`plan.toml`](#plantoml-toml))                                 |
 | `<platform>`         | `CNB_PLATFORM_DIR`     | `/platform`              | Path to platform directory                                                                      |
 | `<uid>`              | `CNB_USER_ID`          |                          | UID of the build image `User`                                                                   |
-| `<build-config>`     | `CNB_BUILD_CONFIG_DIR` | `/cnb/build-config`      | Path to operator-defined environment variables                                                  |
 
 ##### Outputs
 
@@ -562,7 +558,6 @@ Usage:
 /cnb/lifecycle/builder \
   [-app <app>] \
   [-buildpacks <buildpacks>] \
-  [-build-config <buildConfig>]
   [-group <group>] \
   [-layers <layers>] \
   [-log-level <log-level>] \
@@ -571,16 +566,15 @@ Usage:
 ```
 
 ##### Inputs
-| Input            | Env                    | Default Value         | Description                                                                                    |
-|------------------|------------------------|-----------------------|------------------------------------------------------------------------------------------------|
-| `<app>`          | `CNB_APP_DIR`          | `/workspace`          | Path to application directory                                                                  |
-| `<buildpacks>`   | `CNB_BUILDPACKS_DIR`   | `/cnb/buildpacks`     | Path to buildpacks directory (see [Buildpacks Directory Layout](#buildpacks-directory-layout)) |
-| `<group>`        | `CNB_GROUP_PATH`       | `<layers>/group.toml` | Path to group definition (see [`group.toml`](#grouptoml-toml))                                 |
-| `<layers>`       | `CNB_LAYERS_DIR`       | `/layers`             | Path to layers directory                                                                       |
-| `<log-level>`    | `CNB_LOG_LEVEL`        | `info`                | Log Level                                                                                      |
-| `<plan>`         | `CNB_PLAN_PATH`        | `<layers>/plan.toml`  | Path to resolved build plan (see [`plan.toml`](#plantoml-toml))                                |
-| `<platform>`     | `CNB_PLATFORM_DIR`     | `/platform`           | Path to platform directory                                                                     |
-| `<build-config>` | `CNB_BUILD_CONFIG_DIR` | `/cnb/build-config`   | Path to operator-defined environment variables                                                 |
+| Input          | Env                   | Default Value         | Description
+|----------------|-----------------------|-----------------------|----------------------
+| `<app>`        | `CNB_APP_DIR`         | `/workspace`          | Path to application directory
+| `<buildpacks>` | `CNB_BUILDPACKS_DIR`  | `/cnb/buildpacks`     | Path to buildpacks directory (see [Buildpacks Directory Layout](#buildpacks-directory-layout))
+| `<group>`      | `CNB_GROUP_PATH`      | `<layers>/group.toml` | Path to group definition (see [`group.toml`](#grouptoml-toml))
+| `<layers>`     | `CNB_LAYERS_DIR`      | `/layers`             | Path to layers directory
+| `<log-level>`  | `CNB_LOG_LEVEL`       | `info`                | Log Level
+| `<plan>`       | `CNB_PLAN_PATH`       | `<layers>/plan.toml`  | Path to resolved build plan (see [`plan.toml`](#plantoml-toml))
+| `<platform>`   | `CNB_PLATFORM_DIR`    | `/platform`           | Path to platform directory
 
 ##### Outputs
 | Output                                     | Description
@@ -1019,19 +1013,6 @@ Each file SHALL define a single environment variable, where the file name define
 User-provided environment variables MAY be modified by prior buildpacks before they are provided to a given buildpack.
 
 The platform SHOULD NOT set user-provided environment variables directly in the lifecycle execution environment.
-
-The `<platform>/env/` directory follows the same convention as [Environment Variable Modification Rules](https://github.com/buildpacks/spec/blob/main/buildpack.md#environment-variable-modification-rules).
-
-##### Operator-Defined Variables
-Operator-provided environment varaiables MUST be supplied by the platform as files in the `CNB_BUILD_CONFIG_DIR` directory.
-
-Each file SHALL define a single environment variable, where the file name defines the key and the file contents define the value.
-
-Operator-defined environment variables MAY be modified by subsequent buildpacks before they are provided to a given buildpack.
-
-The platform MUST set operator-provided environment variables directly in the lifecycle execution environment.
-
-The `CNB_BUILD_CONFIG_DIR` directory follows the same convention as [Environment Variable Modification Rules](https://github.com/buildpacks/spec/blob/main/buildpack.md#environment-variable-modification-rules).
 
 #### Launch Environment
 User-provided modifications to the process execution environment SHOULD be set directly in the lifecycle execution environment.

--- a/platform.md
+++ b/platform.md
@@ -367,6 +367,7 @@ Usage:
   [-app <app>] \
   [-analyzed <analyzed>] \
   [-buildpacks <buildpacks>] \
+  [-build-config <buildConfig>]
   [-extensions <extensions>] \
   [-generated <generated>] \
   [-group <group>] \
@@ -378,19 +379,21 @@ Usage:
 ```
 
 ##### Inputs
-| Input          | Environment Variable | Default Value                                          | Description                                                                                                                                                  |
-|----------------|----------------------|--------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `<analyzed>`   | `CNB_ANALYZED_PATH`  | `<layers>/analyzed.toml`                               | (**[experimental](#experimental-features)**) Path to output analysis metadata (see [`analyzed.toml`](#analyzedtoml-toml)                                     |
-| `<app>`        | `CNB_APP_DIR`        | `/workspace`                                           | Path to application directory                                                                                                                                |
-| `<buildpacks>` | `CNB_BUILDPACKS_DIR` | `/cnb/buildpacks`                                      | Path to buildpacks directory (see [Buildpacks Directory Layout](#buildpacks-directory-layout))                                                               |
-| `<extensions>` | `CNB_EXTENSIONS_DIR` | `/cnb/extensions`                                      | (**[experimental](#experimental-features)**) Path to image extensions directory (see [Image Extensions Directory Layout](#image-extensions-directory-layout) |
-| `<generated>`  | `CNB_GENERATED_DIR`  | `<layers>/generated`                                   | (**[experimental](#experimental-features)**) Path to output directory for generated Dockerfiles                                                              |
-| `<group>`      | `CNB_GROUP_PATH`     | `<layers>/group.toml`                                  | Path to output group definition                                                                                                                              |
-| `<layers>`     | `CNB_LAYERS_DIR`     | `/layers`                                              | Path to layers directory                                                                                                                                     |
-| `<log-level>`  | `CNB_LOG_LEVEL`      | `info`                                                 | Log Level                                                                                                                                                    |
-| `<order>`      | `CNB_ORDER_PATH`     | `<layers>/order.toml` if present, or `/cnb/order.toml` | Path resolution for order definition (see [`order.toml`](#ordertoml-toml))                                                                                   |
-| `<plan>`       | `CNB_PLAN_PATH`      | `<layers>/plan.toml`                                   | Path to output resolved build plan                                                                                                                           |
-| `<platform>`   | `CNB_PLATFORM_DIR`   | `/platform`                                            | Path to platform directory                                                                                                                                   |
+| Input            | Environment Variable   | Default Value                                          | Description                                                                                                                                                  |
+|------------------|------------------------|--------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `<analyzed>`     | `CNB_ANALYZED_PATH`    | `<layers>/analyzed.toml`                               | (**[experimental](#experimental-features)**) Path to output analysis metadata (see [`analyzed.toml`](#analyzedtoml-toml)                                     |
+| `<app>`          | `CNB_APP_DIR`          | `/workspace`                                           | Path to application directory                                                                                                                                |
+| `<buildpacks>`   | `CNB_BUILDPACKS_DIR`   | `/cnb/buildpacks`                                      | Path to buildpacks directory (see [Buildpacks Directory Layout](#buildpacks-directory-layout))                                                               |
+| `<extensions>`   | `CNB_EXTENSIONS_DIR`   | `/cnb/extensions`                                      | (**[experimental](#experimental-features)**) Path to image extensions directory (see [Image Extensions Directory Layout](#image-extensions-directory-layout) |
+| `<generated>`    | `CNB_GENERATED_DIR`    | `<layers>/generated`                                   | (**[experimental](#experimental-features)**) Path to output directory for generated Dockerfiles                                                              |
+| `<group>`        | `CNB_GROUP_PATH`       | `<layers>/group.toml`                                  | Path to output group definition                                                                                                                              |
+| `<layers>`       | `CNB_LAYERS_DIR`       | `/layers`                                              | Path to layers directory                                                                                                                                     |
+| `<log-level>`    | `CNB_LOG_LEVEL`        | `info`                                                 | Log Level                                                                                                                                                    |
+| `<order>`        | `CNB_ORDER_PATH`       | `<layers>/order.toml` if present, or `/cnb/order.toml` | Path resolution for order definition (see [`order.toml`](#ordertoml-toml))                                                                                   |
+| `<plan>`         | `CNB_PLAN_PATH`        | `<layers>/plan.toml`                                   | Path to output resolved build plan                                                                                                                           |
+| `<platform>`     | `CNB_PLATFORM_DIR`     | `/platform`                                            | Path to platform directory                                                                                                                                   |
+| `<build-config>` | `CNB_BUILD_CONFIG_DIR` | `/cnb/build-config`                                    | Path to operator-defined environment variables                                                                                                               |
+
 
 ##### Outputs
 | Output                                                   | Description                                                                                   |
@@ -524,6 +527,7 @@ Usage:
 | `<plan>`             | `CNB_PLAN_PATH`        | `<layers>/plan.toml`     | Path to resolved build plan (see [`plan.toml`](#plantoml-toml))                                 |
 | `<platform>`         | `CNB_PLATFORM_DIR`     | `/platform`              | Path to platform directory                                                                      |
 | `<uid>`              | `CNB_USER_ID`          |                          | UID of the build image `User`                                                                   |
+| `<build-config>`     | `CNB_BUILD_CONFIG_DIR` | `/cnb/build-config`      | Path to operator-defined environment variables                                                  |
 
 ##### Outputs
 
@@ -558,6 +562,7 @@ Usage:
 /cnb/lifecycle/builder \
   [-app <app>] \
   [-buildpacks <buildpacks>] \
+  [-build-config <buildConfig>]
   [-group <group>] \
   [-layers <layers>] \
   [-log-level <log-level>] \
@@ -566,15 +571,16 @@ Usage:
 ```
 
 ##### Inputs
-| Input          | Env                   | Default Value         | Description
-|----------------|-----------------------|-----------------------|----------------------
-| `<app>`        | `CNB_APP_DIR`         | `/workspace`          | Path to application directory
-| `<buildpacks>` | `CNB_BUILDPACKS_DIR`  | `/cnb/buildpacks`     | Path to buildpacks directory (see [Buildpacks Directory Layout](#buildpacks-directory-layout))
-| `<group>`      | `CNB_GROUP_PATH`      | `<layers>/group.toml` | Path to group definition (see [`group.toml`](#grouptoml-toml))
-| `<layers>`     | `CNB_LAYERS_DIR`      | `/layers`             | Path to layers directory
-| `<log-level>`  | `CNB_LOG_LEVEL`       | `info`                | Log Level
-| `<plan>`       | `CNB_PLAN_PATH`       | `<layers>/plan.toml`  | Path to resolved build plan (see [`plan.toml`](#plantoml-toml))
-| `<platform>`   | `CNB_PLATFORM_DIR`    | `/platform`           | Path to platform directory
+| Input            | Env                    | Default Value         | Description                                                                                    |
+|------------------|------------------------|-----------------------|------------------------------------------------------------------------------------------------|
+| `<app>`          | `CNB_APP_DIR`          | `/workspace`          | Path to application directory                                                                  |
+| `<buildpacks>`   | `CNB_BUILDPACKS_DIR`   | `/cnb/buildpacks`     | Path to buildpacks directory (see [Buildpacks Directory Layout](#buildpacks-directory-layout)) |
+| `<group>`        | `CNB_GROUP_PATH`       | `<layers>/group.toml` | Path to group definition (see [`group.toml`](#grouptoml-toml))                                 |
+| `<layers>`       | `CNB_LAYERS_DIR`       | `/layers`             | Path to layers directory                                                                       |
+| `<log-level>`    | `CNB_LOG_LEVEL`        | `info`                | Log Level                                                                                      |
+| `<plan>`         | `CNB_PLAN_PATH`        | `<layers>/plan.toml`  | Path to resolved build plan (see [`plan.toml`](#plantoml-toml))                                |
+| `<platform>`     | `CNB_PLATFORM_DIR`     | `/platform`           | Path to platform directory                                                                     |
+| `<build-config>` | `CNB_BUILD_CONFIG_DIR` | `/cnb/build-config`   | Path to operator-defined environment variables                                                 |
 
 ##### Outputs
 | Output                                     | Description

--- a/platform.md
+++ b/platform.md
@@ -1020,6 +1020,19 @@ User-provided environment variables MAY be modified by prior buildpacks before t
 
 The platform SHOULD NOT set user-provided environment variables directly in the lifecycle execution environment.
 
+The `<platform>/env/` directory follows the same convention as [Environment Variable Modification Rules](https://github.com/buildpacks/spec/blob/main/buildpack.md#environment-variable-modification-rules).
+
+##### Operator-Defined Variables
+Operator-provided environment varaiables MUST be supplied by the platform as files in the `CNB_BUILD_CONFIG_DIR` directory.
+
+Each file SHALL define a single environment variable, where the file name defines the key and the file contents define the value.
+
+Operator-defined environment variables MAY be modified by subsequent buildpacks before they are provided to a given buildpack.
+
+The platform MUST set operator-provided environment variables directly in the lifecycle execution environment.
+
+The `CNB_BUILD_CONFIG_DIR` directory follows the same convention as [Environment Variable Modification Rules](https://github.com/buildpacks/spec/blob/main/buildpack.md#environment-variable-modification-rules).
+
 #### Launch Environment
 User-provided modifications to the process execution environment SHOULD be set directly in the lifecycle execution environment.
 


### PR DESCRIPTION
RFC https://github.com/buildpacks/spec/pull/109 defines a directory
allowing operators to set environment variables for detect and build
phases.  Specify how the buildpack phases should implement the
behavior.