### PR TITLE
add lifecycle output to update stack after rebase

### DIFF
--- a/platform.md
+++ b/platform.md
@@ -840,8 +840,9 @@ Usage:
       - `run-image.reference` SHALL uniquely identify `<run-image>`
       - `run-image.top-layer` SHALL be set to the uncompressed digest of the top layer in `<run-image>`
     - The value of `io.buildpacks.stack.*` labels SHALL be modified to that of the new `run-image`
-      - `stack.run-image.image` SHALL uniquely identify `<run-image>`
-      - `stack.run-image.mirrors` SHALL be EMPTY
+- **If** the provided `<run-image>` is not found in `stack.run-image.image` or `stack.run-image.mirrors`:
+      - `stack.run-image.image` SHALL be the provided `<run-image>`
+      - `stack.run-image.mirrors` SHALL be omitted
 - To ensure [build reproducibility](#build-reproducibility), the lifecycle:
     - SHOULD set the `created` time in image config to a constant
 

--- a/platform.md
+++ b/platform.md
@@ -824,7 +824,7 @@ Usage:
       - `run-image.reference` SHALL uniquely identify `<run-image>`
       - `run-image.top-layer` SHALL be set to the uncompressed digest of the top layer in `<run-image>`
     - The value of `io.buildpacks.stack.*` labels SHALL be modified to that of the new `run-image`
-- **If** the provided `<run-image>` is not found in `stack.run-image.image` or `stack.run-image.mirrors`:
+- **If** the provided `<run-image>` is not found in `runImage.image` or `runImage.mirrors`:
       - `run-image.image` SHALL be the provided `<run-image>`
       - `run-image.mirrors` SHALL be omitted
 - To ensure [build reproducibility](#build-reproducibility), the lifecycle:

--- a/platform.md
+++ b/platform.md
@@ -825,8 +825,8 @@ Usage:
       - `run-image.top-layer` SHALL be set to the uncompressed digest of the top layer in `<run-image>`
     - The value of `io.buildpacks.stack.*` labels SHALL be modified to that of the new `run-image`
 - **If** the provided `<run-image>` is not found in `stack.run-image.image` or `stack.run-image.mirrors`:
-      - `stack.run-image.image` SHALL be the provided `<run-image>`
-      - `stack.run-image.mirrors` SHALL be omitted
+      - `run-image.image` SHALL be the provided `<run-image>`
+      - `run-image.mirrors` SHALL be omitted
 - To ensure [build reproducibility](#build-reproducibility), the lifecycle:
     - SHOULD set the `created` time in image config to a constant
 

--- a/platform.md
+++ b/platform.md
@@ -822,7 +822,7 @@ Usage:
 | [exit status]      | (see Exit Code table below for values)
 | `/dev/stdout`      | Logs (info)
 | `/dev/stderr`      | Logs (warnings, errors)
-| `<image>`          | Rebased app image (see [Buildpack Interface Specfication](buildpack.md)
+| `<image>`          | Rebased app image (see [Buildpack Interface Specfication](buildpack.md))
 
 | Exit Code | Result|
 |-----------|-------|
@@ -840,6 +840,8 @@ Usage:
       - `run-image.reference` SHALL uniquely identify `<run-image>`
       - `run-image.top-layer` SHALL be set to the uncompressed digest of the top layer in `<run-image>`
     - The value of `io.buildpacks.stack.*` labels SHALL be modified to that of the new `run-image`
+      - `stack.run-image.image` SHALL uniquely identify `<run-image>`
+      - `stack.run-image.mirrors` SHALL be EMPTY
 - To ensure [build reproducibility](#build-reproducibility), the lifecycle:
     - SHOULD set the `created` time in image config to a constant
 


### PR DESCRIPTION
This is related to https://github.com/buildpacks/lifecycle/issues/1098

As for now the Spec is missing to specify the need to update the Stack metadata so it will reflect new information after image rebase process