### PR TITLE
Allow metadata for extension.toml

### DIFF
--- a/image_extension.md
+++ b/image_extension.md
@@ -155,6 +155,9 @@ keywords = [ "<string>" ]
 [[extension.licenses]]
 type = "<string>"
 uri = "<uri>"
+
+[metadata]
+# extension-specific data
 ```
 
 Image extension authors MUST choose a globally unique ID, for example: "io.buildpacks.apt".


### PR DESCRIPTION
extension.toml as defined by spec omits [metadata] section. 
Discussion via slack suggested this was non-intentional. 
This PR adds the metadata block to the spec definiton of the extension.toml file