### PR TITLE
Buildpack spec: clarify target requirements and matching logic

### DIFF
--- a/buildpack.md
+++ b/buildpack.md
@@ -756,7 +756,7 @@ The following environment variables MUST be set by the lifecycle during the `det
 | `CNB_TARGET_ID`             | Identifier for the target image (optional) |
 | `CNB_TARGET_OS`             | Target OS                                  |
 | `CNB_TARGET_ARCH`           | Target architecture                        |
-| `CNB_TARGET_ARCH_VARIANT`        | Target architecture variant (optional)     |
+| `CNB_TARGET_ARCH_VARIANT`   | Target architecture variant (optional)     |
 | `CNB_TARGET_DISTRO_NAME`    | Target OS distribution name (optional)     |
 | `CNB_TARGET_DISTRO_VERISON` | Target OS distribution version (optional)  |
 
@@ -1107,21 +1107,18 @@ A buildpack descriptor SHOULD specify `targets`.
 
 Each target in `targets`:
 - MUST identify a compatible runtime environment:
-   - `os` and `arch` are required and MUST be valid identifiers as defined in the [OCI Image Specification](https://github.com/opencontainers/image-spec/blob/main/config.md)
-   - `variant` is optional and MUST be a valid identifier as defined in the [OCI Image Specification](https://github.com/opencontainers/image-spec/blob/main/config.md)
-   - `distributions` are optional and MUST describe the OS distributions supported by the buildpack
+   - `os`, `arch`, and `variant` if provided MUST be valid identifiers as defined in the [OCI Image Specification](https://github.com/opencontainers/image-spec/blob/main/config.md)
+   - `distributions` if provided MUST describe the OS distributions supported by the buildpack
      - For Linux-based images, `distributions.name` and `distributions.versions` SHOULD contain the values specified in `/etc/os-release` (`$ID` and `$VERSION_ID`), as the `os.version` field in an image config may contain combined distribution and version information
      - For Windows-based images, `distributions.name` SHOULD be empty; `distributions.versions` SHOULD contain the value of `os.version` in the image config (e.g., `10.0.14393.1066`)
+   - Any field not provided will be interpreted as `<matches any>`
 
 If the `targets` list is empty, tools reading `buildpack.toml` will assume:
   - `os = "linux"` and `arch = <matches any>` if `./bin/build` is present
   - `os = "windows"` and `arch = <matches any>` if `./bin/build.bat` or `./bin/build.exe` are present
-  - `os = <matches any>` and `arch = <matches any>` for extensions
 
 Metadata specified in `[[targets]]` is validated against the runtime and build-time base images.
-* A buildpack target satisfies a base image target when:
-  * `os` and `arch` match, and
-  * Optional fields either match exactly, or are left blank by at least one target (blank values match any other value)
+* A buildpack target satisfies a base image target when `os`, `arch`, and `variant` match and at least one distribution in `distributions` (if provided) matches
    
 #### Order
 


### PR DESCRIPTION
Rather than allow special values of `*` we should just make all fields optional and interpret them as wildcard matches when omitted. 