### PR TITLE
Remove CNB_TARGET_ID from the Buildpack API

### DIFF
--- a/buildpack.md
+++ b/buildpack.md
@@ -753,7 +753,6 @@ The following environment variables MUST be set by the lifecycle during the `det
 
 | Env Variable                | Description                                |
 |-----------------------------|--------------------------------------------|
-| `CNB_TARGET_ID`             | Identifier for the target image (optional) |
 | `CNB_TARGET_OS`             | Target OS                                  |
 | `CNB_TARGET_ARCH`           | Target architecture                        |
 | `CNB_TARGET_ARCH_VARIANT`   | Target architecture variant (optional)     |


### PR DESCRIPTION
For further context, see https://cloud-native.slack.com/archives/C033DV8D9FB/p1691077392008629