### PR TITLE
Platform API changes to enable exporting app image and cache image in parallel

### DIFF
--- a/platform.md
+++ b/platform.md
@@ -728,7 +728,7 @@ Usage:
 | `<layout>`                      | `CNB_USE_LAYOUT`            | false                            | (**[experimental](#experimental-features)**) Export image to disk in OCI layout format     |
 | `<layout-dir>`                  | `CNB_LAYOUT_DIR`            |                                  | (**[experimental](#experimental-features)**) Path to a root directory where the images are saved in OCI layout format |
 | `<log-level>`                   | `CNB_LOG_LEVEL`             | `info`                           | Log Level                                                                                  |
-| `<parallel>`                    | `CNB_PARALLEL_EXPORT`       | false                            | Export app image and cache image in parallel                                               |
+| `<parallel>`                    | `CNB_PARALLEL_EXPORT`       | false                            | Export app image and cache in parallel                                               |
 | `<process-type>`                | `CNB_PROCESS_TYPE`          |                                  | Default process type to set in the exported image                                          |
 | `<project-metadata>`            | `CNB_PROJECT_METADATA_PATH` | `<layers>/project-metadata.toml` | Path to a project metadata file (see [`project-metadata.toml`](#project-metadatatoml-toml) |
 | `<report>`                      | `CNB_REPORT_PATH`           | `<layers>/report.toml`           | Path to report (see [`report.toml`](#reporttoml-toml)                                      |

--- a/platform.md
+++ b/platform.md
@@ -698,6 +698,7 @@ Usage:
   [-layout] \ # sets <layout>
   [-layout-dir] \ # sets <layout-dir>
   [-log-level <log-level>] \
+  [-parallel] \
   [-process-type <process-type> ] \
   [-project-metadata <project-metadata> ] \
   [-report <report> ] \
@@ -727,6 +728,7 @@ Usage:
 | `<layout>`                      | `CNB_USE_LAYOUT`            | false                            | (**[experimental](#experimental-features)**) Export image to disk in OCI layout format     |
 | `<layout-dir>`                  | `CNB_LAYOUT_DIR`            |                                  | (**[experimental](#experimental-features)**) Path to a root directory where the images are saved in OCI layout format |
 | `<log-level>`                   | `CNB_LOG_LEVEL`             | `info`                           | Log Level                                                                                  |
+| `<parallel>`                    | `CNB_PARALLEL_EXPORT`       | false                            | Export app image and cache image in parallel                                               |
 | `<process-type>`                | `CNB_PROCESS_TYPE`          |                                  | Default process type to set in the exported image                                          |
 | `<project-metadata>`            | `CNB_PROJECT_METADATA_PATH` | `<layers>/project-metadata.toml` | Path to a project metadata file (see [`project-metadata.toml`](#project-metadatatoml-toml) |
 | `<report>`                      | `CNB_REPORT_PATH`           | `<layers>/report.toml`           | Path to report (see [`report.toml`](#reporttoml-toml)                                      |


### PR DESCRIPTION
Platform API changes to enable exporting app image and cache image in parallel