### PR TITLE
Finalize Platform 0.14

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,4 @@ These documents currently specify:
 
 - Buildpack API: `0.10`
 - Distribution API: `0.3`
-- Platform API: `0.12`
+- Platform API: `0.14`

--- a/platform.md
+++ b/platform.md
@@ -98,7 +98,7 @@ Examples of a platform might include:
 
 ## Platform API Version
 
-This document specifies Platform API version `0.12`.
+This document specifies Platform API version `0.14`.
 
 Platform API versions:
  - MUST be in form `<major>.<minor>` or `<major>`, where `<major>` is equivalent to `<major>.0`


### PR DESCRIPTION
Release notes

This release of the Cloud Native Buildpacks Specification defines Platform API 0.14.

Additions

* The `restorer` accepts a `-run` flag (https://github.com/buildpacks/spec/pull/408)