### PR TITLE
Finalize Buildpack 0.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,6 @@ When the specification refers to a path in the context of an OCI layer tar (e.g.
 
 These documents currently specify:
 
-- Buildpack API: `0.10`
+- Buildpack API: `0.12`
 - Distribution API: `0.3`
 - Platform API: `0.12`

--- a/buildpack.md
+++ b/buildpack.md
@@ -816,7 +816,7 @@ The following additional environment variables MUST NOT be overridden by the lif
 | `HOME`                 | Current user's home directory                     | [x]    | [x]   | [x]    |
 
 During the detection and build phases, the lifecycle MUST provide as environment variables any user-provided files in `<platform>/env/` with environment variable names and contents matching the file names and contents.
-During the detection and build phases, the lifecycle MUST provide as environment variables any operator-provided files in `CNB_PLATFORM_DIR/env` with environment variable names and contents matching the file names and contents. This applies for all values of `clear-env` or if `clear-env` is undefined in `buildpack.toml`.
+During the detection and build phases, the lifecycle MUST provide as environment variables any operator-provided files in `<platform>/env` with environment variable names and contents matching the file names and contents. This applies for all values of `clear-env` or if `clear-env` is undefined in `buildpack.toml`.
 
 When `clear-env` in `buildpack.toml` is set to `true` for a given buildpack, the lifecycle MUST NOT set user-provided environment variables in the environment of `/bin/detect` or `/bin/build`. The user-provided files in `<platform>/env/` contents will still be available.
 

--- a/buildpack.md
+++ b/buildpack.md
@@ -251,20 +251,22 @@ The lifecycle MUST treat a layer with unset `types` as a `launch = false`, `buil
 The following table illustrates the behavior depending on the value of each flag.
 Note that the lifecycle only restores layers from the cache, never from the previous image.
 
-`build`   | `cache`  | `launch` | Metadata and SBOM** Restored | Layer Restored
-----------|----------|----------|------------------------------|---------------------
-true      | true     | true     | Yes - from the app image     | Yes* - from the cache
-true      | true     | false    | Yes - from the cache         | Yes - from the cache
-true      | false    | true     | No                           | No
-true      | false    | false    | No                           | No
-false     | true     | true     | Yes - from the app image     | Yes* - from the cache
-false     | true     | false    | Yes - from the cache         | Yes - from the cache
-false     | false    | true     | Yes - from the app image     | No
-false     | false    | false    | No                           | No
+| `build` | `cache` | `launch` | Metadata and SBOM** Restored | Layer Restored        |
+| ------- | ------- | -------- | ---------------------------- | --------------------- |
+| true    | true    | true     | Yes - from the app image***  | Yes* - from the cache |
+| true    | true    | false    | Yes - from the cache         | Yes - from the cache  |
+| true    | false   | true     | No                           | No                    |
+| true    | false   | false    | No                           | No                    |
+| false   | true    | true     | Yes - from the app image***  | Yes* - from the cache |
+| false   | true    | false    | Yes - from the cache         | Yes - from the cache  |
+| false   | false   | true     | Yes - from the app image     | No                    |
+| false   | false   | false    | No                           | No                    |
 
-\* The metadata and layer are restored only if the layer SHA recorded in the previous image matches the layer SHA recorded in the cache.
+\* If the previous image was found, the metadata and layer are restored only if the layer SHA recorded in the image matches the layer SHA recorded in the cache.
 
 \** Only SBOM files associated with a layer are restored. Launch-level and build-level SBOM files must be re-created on each build.
+
+\*** If the app image is not found or it is missing cached metadata for a layer, the metadata will be restored from the cache, if found.
 
 Examples:
 * `build = true, cache = true, launch = true`:

--- a/buildpack.md
+++ b/buildpack.md
@@ -264,8 +264,6 @@ Note that the lifecycle only restores layers from the cache, never from the prev
 
 \** Only SBOM files associated with a layer are restored. Launch-level and build-level SBOM files must be re-created on each build.
 
-\*** If the app image is not found or it is missing cached metadata for a layer, the metadata will be restored from the cache, if found.
-
 Examples:
 * `build = true, cache = true, launch = true`:
 A Ruby buildpack provides the Ruby interpreter to a subsequent buildpack and additionally installs Ruby in the app image to support the application. The Ruby is restored from the cache on rebuild, and the Ruby buildpack can use layer metadata to ensure the correct version is present.

--- a/buildpack.md
+++ b/buildpack.md
@@ -262,8 +262,6 @@ Note that the lifecycle only restores layers from the cache, never from the prev
 | false   | false   | true     | Yes - from the app image     | No                    |
 | false   | false   | false    | No                           | No                    |
 
-\* If the previous image was found, the metadata and layer are restored only if the layer SHA recorded in the image matches the layer SHA recorded in the cache.
-
 \** Only SBOM files associated with a layer are restored. Launch-level and build-level SBOM files must be re-created on each build.
 
 \*** If the app image is not found or it is missing cached metadata for a layer, the metadata will be restored from the cache, if found.

--- a/buildpack.md
+++ b/buildpack.md
@@ -816,7 +816,7 @@ The following additional environment variables MUST NOT be overridden by the lif
 | `HOME`                 | Current user's home directory                     | [x]    | [x]   | [x]    |
 
 During the detection and build phases, the lifecycle MUST provide as environment variables any user-provided files in `<platform>/env/` with environment variable names and contents matching the file names and contents.
-During the detection and build phases, the lifecycle MUST provide as environment variables any operator-provided files in `<build-config>/env` with environment variable names and contents matching the file names and contents. This applies for all values of `clear-env` or if `clear-env` is undefined in `buildpack.toml`.
+During the detection and build phases, the lifecycle MUST provide as environment variables any operator-provided files in `CNB_PLATFORM_DIR/env` with environment variable names and contents matching the file names and contents. This applies for all values of `clear-env` or if `clear-env` is undefined in `buildpack.toml`.
 
 When `clear-env` in `buildpack.toml` is set to `true` for a given buildpack, the lifecycle MUST NOT set user-provided environment variables in the environment of `/bin/detect` or `/bin/build`. The user-provided files in `<platform>/env/` contents will still be available.
 

--- a/buildpack.md
+++ b/buildpack.md
@@ -818,7 +818,7 @@ The following additional environment variables MUST NOT be overridden by the lif
 During the detection and build phases, the lifecycle MUST provide as environment variables any user-provided files in `<platform>/env/` with environment variable names and contents matching the file names and contents.
 During the detection and build phases, the lifecycle MUST provide as environment variables any operator-provided files in `<build-config>/env` with environment variable names and contents matching the file names and contents. This applies for all values of `clear-env` or if `clear-env` is undefined in `buildpack.toml`.
 
-When `clear-env` in `buildpack.toml` is set to `true` for a given buildpack, the lifecycle MUST NOT set user-provided environment variables in the environment of `/bin/detect` or `/bin/build`.
+When `clear-env` in `buildpack.toml` is set to `true` for a given buildpack, the lifecycle MUST NOT set user-provided environment variables in the environment of `/bin/detect` or `/bin/build`. The user-provided files in `<platform>/env/` contents will still be available.
 
 When `clear-env` in `buildpack.toml` is not set to `true` for a given buildpack, the lifecycle MUST set user-provided environment variables in the environment of `/bin/detect` or `/bin/build` such that:
 1. For layer path environment variables, user-provided values are prepended before any existing values and are delimited by the OS path list separator.

--- a/buildpack.md
+++ b/buildpack.md
@@ -82,7 +82,7 @@ This document specifies the interface between a lifecycle program and one or mor
     - [Build Plan (TOML) `requires.version` Key](#build-plan-toml-requiresversion-key)
 
 ## Buildpack API Version
-This document specifies Buildpack API version `0.10`
+This document specifies Buildpack API version `0.12`
 
 Buildpack API versions:
  - MUST be in form `<major>.<minor>` or `<major>`, where `<major>` is equivalent to `<major>.0`

--- a/buildpack.md
+++ b/buildpack.md
@@ -224,10 +224,10 @@ OR
 Executable: `<layers>/<layer>/exec.d/<process>/<executable>`, Working Dir: `<app[AI]>`
 
 | Input                                          | Description
-|------------------------------------------------|----------------------------------------------
+|------------------------------------------------|----------------------------------------------------------------------------------
 | `$0`                                           | Absolute path of the executable
-| [†](README.md#linux-only)FD 3                  | A third open file descriptor
-| [‡](README.md#windows-only) `<handle>`         | An additional open handle
+| [†](README.md#linux-only)FD 3                  | A third open file descriptor inherited by `<executable>` from the calling process
+| [‡](README.md#windows-only) `<handle>`         | An additional open handle inherited by `<executable>` from the calling process
 | [‡](README.md#windows-only)`CNB_EXEC_D_HANDLE` | Hexidecimal number for `<handle>`
 
 | Output             | Description
@@ -921,7 +921,7 @@ For each label, the buildpack:
 
 The lifecycle MUST add each label as an image label on the created image metadata.
 
-If multiple buildpacks define labels with the same key, the lifecycle MUST use the last label defintion ordered by buildpack execution for the image label.
+If multiple buildpacks define labels with the same key, the lifecycle MUST use the last label definition ordered by buildpack execution for the image label.
 
 For each process, the buildpack:
 

--- a/buildpack.md
+++ b/buildpack.md
@@ -1075,17 +1075,20 @@ sbom-formats = [ "<string>" ]
 type = "<string>"
 uri = "<uri>"
 
+[[buildpack.exec-env]]
+name = "<execution environment>"
+
 [[order]]
 [[order.group]]
 id = "<buildpack ID>"
 version = "<buildpack version>"
 optional = false
+exec-env = ["<execution environment>"]
 
 [[targets]]
 os = "<OS name>"
 arch = "<architecture>"
 variant = "<architecture variant>"
-exec-env = ["<execution environment>"] # Optional. If not specified, applies to all execution environments
 [[targets.distros]]
 name = "<OS distribution name>"
 version = "<OS distribution version>"
@@ -1122,6 +1125,12 @@ The `[[buildpack.licenses]]` table is optional and MAY contain a list of buildpa
 - `type` - This MAY use the SPDX 2.1 license expression, but is not limited to identifiers in the SPDX Licenses List.
 - `uri` - If this buildpack is using a nonstandard license, then this key MAY be specified in lieu of or in addition to `type` to point to the license.
 
+**The buildpack execution environments:**
+
+The `[[buildpack.exec-env]]` table is optional and MAY contain a list of execution environments that the buildpack supports where:
+
+- `name` - This MUST specify an execution environment name (e.g., "production", "test", "development").
+
 **The buildpack SBOM:**
 
 *Key: `sbom-formats = [ "<string>" ]`*
@@ -1134,7 +1143,6 @@ A buildpack descriptor SHOULD specify `targets`.
 Each target in `targets`:
 - MUST identify a compatible runtime environment:
    - `os`, `arch`, and `variant` if provided MUST be valid identifiers as defined in the [OCI Image Specification](https://github.com/opencontainers/image-spec/blob/main/config.md)
-   - `exec-env` if provided MUST specify one or more execution environments for which the buildpack is compatible (e.g., "production", "test", "development")
    - `distros` if provided MUST describe the OS distributions supported by the buildpack
      - For Linux-based images, `distros.name` and `distros.version` SHOULD contain the values specified in `/etc/os-release` (`$ID` and `$VERSION_ID`), as the `os.version` field in an image config may contain combined distribution and version information
      - For Windows-based images, `distros.name` SHOULD be empty; `distros.version` SHOULD contain the value of `os.version` in the image config (e.g., `10.0.14393.1066`)
@@ -1150,6 +1158,8 @@ Metadata specified in `[[targets]]` is validated against the runtime and build-t
 #### Order
 
 A buildpack reference inside of a `group` MUST contain an `id` and `version`. The `order` MUST include only buildpacks and MUST NOT include image extensions.
+
+A buildpack reference inside of a `group` MAY contain an `exec-env` array to specify the execution environments for which the buildpack applies.
 
 ### Exec.d Output (TOML)
 ```

--- a/buildpack.md
+++ b/buildpack.md
@@ -927,7 +927,7 @@ command = ["<command>"]
 args = ["<arguments>"]
 default = false
 working-dir = "<working directory>"
-exec-env = ["<execution environment>", ...] # Optional. If not specified, applies to all execution environments
+exec-env = ["<execution environment>"] # Optional. If not specified, applies to all execution environments
 
 [[slices]]
 paths = ["<app sub-path glob>"]
@@ -1042,7 +1042,7 @@ name = "<dependency name>"
   cache = false
 
 [metadata]
-  exec-env = ["<execution environment>", ...] # Optional. If not specified, applies to all execution environments
+  exec-env = ["<execution environment>"] # Optional. If not specified, applies to all execution environments
   # other buildpack-specific data
 ```
 
@@ -1081,7 +1081,7 @@ optional = false
 os = "<OS name>"
 arch = "<architecture>"
 variant = "<architecture variant>"
-exec-env = ["<execution environment>", ...] # Optional. If not specified, applies to all execution environments
+exec-env = ["<execution environment>"] # Optional. If not specified, applies to all execution environments
 [[targets.distros]]
 name = "<OS distribution name>"
 version = "<OS distribution version>"

--- a/buildpack.md
+++ b/buildpack.md
@@ -103,7 +103,7 @@ A **component buildpack** is a buildpack containing `/bin/detect` and `/bin/buil
 
 A **composite buildpack** is a buildpack containing an order definition in `buildpack.toml`. Composite buildpacks do not contain `/bin/detect` or `/bin/build` executables. They MUST be [resolvable](#order-resolution) into a collection of component buildpacks.
 
-An **image extension** is a directory containing an `extension.toml`. Extensions generate Dockerfiles that can be used to define the runtime base image, prior to buildpack execution. Extensions implement the [Image Extension Interface](image-extension.md). Extensions are always "component": their `extension.toml` cannot contain an order definition.
+An **image extension** is a directory containing an `extension.toml`. Extensions generate Dockerfiles that can be used to define the runtime base image, prior to buildpack execution. Extensions implement the [Image Extension Interface](image_extension.md). Extensions are always "component": their `extension.toml` cannot contain an order definition.
 
 **Resolving an order** is the process by which an order (which may contain image extensions, component buildpacks, or composite buildpacks) is evaluated together with application source code to produce an optional group of image extensions and a required group of component buildpacks that can be used to build the application. This process is known as **detection**. During detection, the `/bin/detect` executable for each image extension (if present) and the `/bin/detect` executable for each component buildpack is invoked.
 

--- a/buildpack.md
+++ b/buildpack.md
@@ -158,6 +158,10 @@ Buildpacks MAY optimize their output based on the execution environment:
 
 When the `CNB_EXEC_ENV` environment variable is not set, buildpacks MUST assume the default value of `production`.
 
+The value of `CNB_EXEC_ENV` MUST NOT contain the character `/` as it is reserved for future use.
+
+When a platform builds an application with a different execution environment than was used in a previous build, the platform SHOULD NOT restore layers from the previous build's image. The lifecycle MAY ignore layer metadata from previous builds with different execution environments to ensure proper environment-specific behaviors are maintained.
+
 ### Buildpack API Compatibility
 Given a buildpack declaring `<buildpack API Version>` in its [`buildpack.toml`](#buildpacktoml-toml), the lifecycle:
 - MUST either conform to the matching version of this specification when interfacing with the buildpack or

--- a/buildpack.md
+++ b/buildpack.md
@@ -190,7 +190,7 @@ Executable: `/bin/detect`, Working Dir: `<app[AR]>`
 | `$0`                     |            | Absolute path of `/bin/detect` executable         |
 | `$CNB_BUILD_PLAN_PATH`   | E          | Absolute path of the build plan                   |
 | `$CNB_BUILDPACK_DIR`     | ER         | Absolute path of the buildpack root directory     |
-| `$CNB_EXEC_ENV`          |            | Target execution environment ("production", "test", "development") |
+| `$CNB_EXEC_ENV`          | AR         | Target execution environment ("production", "test", "development") |
 | `$CNB_PLATFORM_DIR`      | AR         | Absolute path of the platform directory           |
 | `$CNB_PLATFORM_DIR/env/` | AR         | User-provided environment variables for build     |
 | `$CNB_PLATFORM_DIR/#`    | AR         | Platform-specific extensions                      |
@@ -212,7 +212,7 @@ Executable: `/bin/build`, Working Dir: `<app[AI]>`
 | `$CNB_LAYERS_DIR`        | EIC        | Absolute path of the buildpack layers directory                               |
 | `$CNB_BP_PLAN_PATH`      | ER         | Relevant [Buildpack Plan entries](#buildpack-plan-toml) from detection (TOML) |
 | `$CNB_BUILDPACK_DIR`     | ER         | Absolute path of the buildpack root directory                                 |
-| `$CNB_EXEC_ENV`          |            | Target execution environment ("production", "test", "development")            |
+| `$CNB_EXEC_ENV`          | AR         | Target execution environment ("production", "test", "development")            |
 | `$CNB_PLATFORM_DIR`      | AR         | Absolute path of the platform directory                                       |
 | `$CNB_PLATFORM_DIR/env/` | AR         | User-provided environment variables for build                                 |
 | `$CNB_PLATFORM_DIR/#`    | AR         | Platform-specific extensions                                                  |
@@ -960,6 +960,7 @@ For each process, the buildpack:
   - The `args` list is a default list of arguments that may be overridden by the user [^command-args].
 - MAY specify a `default` boolean that indicates that the process type should be selected as the [buildpack-provided default](https://github.com/buildpacks/spec/blob/main/platform.md#outputs-4) during the export phase.
 - MAY specify a `working-dir` for the process. The `working-dir` defaults to the application directory if not specified.
+- MAY specify an `exec-env` array to restrict the process to specific execution environments. If `exec-env` is not specified, the process applies to all execution environments.
 
 [^command-args]: For versions of the Platform API that do not support overridable arguments, the arguments in `command` and `args` are always applied together with any user-provided arguments.
 In general, the [Platform Interface Specification](platform.md) is ultimately responsible for launching processes; consult that specification for details.
@@ -1054,6 +1055,7 @@ For a given layer, the buildpack MAY specify:
 
 - Whether the layer is cached, intended for build, and/or intended for launch.
 - Metadata that describes the layer contents.
+- An `exec-env` array in the `[metadata]` section to restrict the layer to specific execution environments. If `exec-env` is not specified, the layer applies to all execution environments.
 
 ### buildpack.toml (TOML)
 This section describes the 'Buildpack descriptor'.

--- a/buildpack.md
+++ b/buildpack.md
@@ -251,18 +251,18 @@ The lifecycle MUST treat a layer with unset `types` as a `launch = false`, `buil
 The following table illustrates the behavior depending on the value of each flag.
 Note that the lifecycle only restores layers from the cache, never from the previous image.
 
-| `build` | `cache` | `launch` | Metadata and SBOM** Restored | Layer Restored        |
-| ------- | ------- | -------- | ---------------------------- | --------------------- |
-| true    | true    | true     | Yes - from the app image***  | Yes* - from the cache |
-| true    | true    | false    | Yes - from the cache         | Yes - from the cache  |
-| true    | false   | true     | No                           | No                    |
-| true    | false   | false    | No                           | No                    |
-| false   | true    | true     | Yes - from the app image***  | Yes* - from the cache |
-| false   | true    | false    | Yes - from the cache         | Yes - from the cache  |
-| false   | false   | true     | Yes - from the app image     | No                    |
-| false   | false   | false    | No                           | No                    |
+| `build` | `cache` | `launch` | Metadata and SBOM* Restored | Layer Restored |
+| ------- | ------- | -------- | --------------------------- | -------------- |
+| true    | true    | true     | Yes                         | Yes            |
+| true    | true    | false    | Yes                         | Yes            |
+| true    | false   | true     | No                          | No             |
+| true    | false   | false    | No                          | No             |
+| false   | true    | true     | Yes                         | Yes*           |
+| false   | true    | false    | Yes                         | Yes            |
+| false   | false   | true     | Yes                         | No             |
+| false   | false   | false    | No                          | No             |
 
-\** Only SBOM files associated with a layer are restored. Launch-level and build-level SBOM files must be re-created on each build.
+\* Only SBOM files associated with a layer are restored. Launch-level and build-level SBOM files must be re-created on each build.
 
 Examples:
 * `build = true, cache = true, launch = true`:


### PR DESCRIPTION
Release Notes

## Additions
   * Execution Environments: Buildpacks can optionally specify supported execution environments (#415, [RFC 0134](https://github.com/buildpacks/rfcs/blob/main/text/0134-execution-environments.md))